### PR TITLE
Adicionando a carteira 17-027 para Banco do Brasil

### DIFF
--- a/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17027Teste.cs
+++ b/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17027Teste.cs
@@ -1,0 +1,103 @@
+using System;
+using BoletoNet;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Boleto.Net.Testes.BancoBrasil
+{
+    [TestClass]
+    public class BancoBrasil17027Teste
+    {
+        #region Carteira 17-027
+
+        private BoletoBancario GerarBoletoCarteira17027()
+        {
+            DateTime vencimento = new DateTime(2012, 6, 14);
+
+            var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0131", "7", "00059127", "0");
+
+            BoletoNet.Boleto boleto = new BoletoNet.Boleto(vencimento, 1700, "17-027", "18204", cedente);
+
+            boleto.NumeroDocumento = "18204";
+
+            var boletoBancario = new BoletoBancario();
+
+            boletoBancario.CodigoBanco = 1;
+
+            boletoBancario.Boleto = boleto;
+
+            return boletoBancario;
+        }
+
+        [TestMethod]
+        public void BancoDoBrasil_Carteira_17027_NossoNumero_ComCodigoConvenio_4Posicoes()
+        {
+            var boletoBancario = GerarBoletoCarteira17027();
+
+            boletoBancario.Cedente.Convenio = 2379;
+
+            boletoBancario.Boleto.Valida();
+
+            string nossoNumeroValido = "17/23790018204";
+
+            Assert.AreEqual(boletoBancario.Boleto.NossoNumero, nossoNumeroValido, "Nosso número inválido para 4 posições");
+        }
+
+        [TestMethod]
+        public void BancoDoBrasil_Carteira_17027_NossoNumero_ComCodigoConvenio_6Posicoes()
+        {
+            var boletoBancario = GerarBoletoCarteira17027();
+
+            boletoBancario.Cedente.Convenio = 237966;
+
+            boletoBancario.Boleto.Valida();
+
+            string nossoNumeroValido = "17/23796618204";
+
+            Assert.AreEqual(boletoBancario.Boleto.NossoNumero, nossoNumeroValido, "Nosso número inválido para 6 posições");
+        }
+
+        [TestMethod]
+        public void BancoDoBrasil_Carteira_17027_NossoNumero_ComCodigoConvenio_7Posicoes()
+        {
+            var boletoBancario = GerarBoletoCarteira17027();
+
+            boletoBancario.Cedente.Convenio = 2379661;
+
+            boletoBancario.Boleto.Valida();
+
+            string nossoNumeroValido = "17/23796610000018204";
+
+            Assert.AreEqual(boletoBancario.Boleto.NossoNumero, nossoNumeroValido, "Nosso número inválido para 7 posições");
+        }
+
+        [TestMethod]
+        public void BancoDoBrasil_Carteira_17027_LinhaDigitavel()
+        {
+            var boletoBancario = GerarBoletoCarteira17027();
+
+            boletoBancario.Cedente.Convenio = 2379661;
+
+            boletoBancario.Boleto.Valida();
+
+            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 9 53640000170000";
+
+            Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
+        }
+
+        [TestMethod]
+        public void BancoDoBrasil_Carteira_17027_CodigoBarra()
+        {
+            var boletoBancario = GerarBoletoCarteira17027();
+
+            boletoBancario.Cedente.Convenio = 2379661;
+
+            boletoBancario.Boleto.Valida();
+
+            string codigoBarraValida = "00199536400001700000000002379661000001820417";
+
+            Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
+        }
+
+        #endregion  Carteira 17-027
+    }
+}

--- a/src/Boleto.Net.Testes/Boleto.Net.Testes.csproj
+++ b/src/Boleto.Net.Testes/Boleto.Net.Testes.csproj
@@ -57,6 +57,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BancoBradescoTeste.cs" />
+    <Compile Include="BancoBrasil\BancoBrasil17027Teste.cs" />
     <Compile Include="BancoBrasil\BancoBrasilCarteira18Teste.cs" />
     <Compile Include="BancoItauTeste.cs" />
     <Compile Include="BancoSantanderTeste.cs" />

--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -47,13 +47,14 @@ namespace BoletoNet
         public override void ValidaBoleto(Boleto boleto)
         {
             if (string.IsNullOrEmpty(boleto.Carteira))
-                throw new NotImplementedException("Carteira não informada. Utilize a carteira 11, 16, 17, 18, 18-019, 18-027, 18-035, 18-140 ou 31.");
+                throw new NotImplementedException("Carteira não informada. Utilize a carteira 11, 16, 17, 17-019, 17-027, 18, 18-019, 18-027, 18-035, 18-140 ou 31.");
 
             //Verifica as carteiras implementadas
             if (!boleto.Carteira.Equals("11") &
                 !boleto.Carteira.Equals("16") &
                 !boleto.Carteira.Equals("17") &
                 !boleto.Carteira.Equals("17-019") &
+                !boleto.Carteira.Equals("17-027") &
                 !boleto.Carteira.Equals("18") &
                 !boleto.Carteira.Equals("18-019") &
                 !boleto.Carteira.Equals("18-027") &
@@ -61,7 +62,7 @@ namespace BoletoNet
                 !boleto.Carteira.Equals("18-140") &
                 !boleto.Carteira.Equals("31"))
 
-                throw new NotImplementedException("Carteira não informada. Utilize a carteira 11, 16, 17, 17-019, 18, 18-019, 18-027, 18-035, 18-140 ou 31.");
+                throw new NotImplementedException("Carteira não informada. Utilize a carteira 11, 16, 17, 17-019, 17-027, 18, 18-019, 18-027, 18-035, 18-140 ou 31.");
 
             //Verifica se o nosso número é válido
             if (Utils.ToString(boleto.NossoNumero) == string.Empty)
@@ -181,6 +182,49 @@ namespace BoletoNet
                     boleto.NossoNumero = Utils.FormatCode(boleto.NossoNumero, 11);
             }
             #endregion Carteira 17-019
+
+            #region Carteira 17-027
+            //Carteira 17, com variação 027
+            if (boleto.Carteira.Equals("17-027"))
+            {
+                /*
+                 * Convênio de 7 posições
+                 * Nosso Número com 17 posições
+                 */
+                if (boleto.Cedente.Convenio.ToString().Length == 7)
+                {
+                    if (boleto.NossoNumero.Length > 10)
+                        throw new NotImplementedException(string.Format("Para a carteira {0}, a quantidade máxima são de 10 de posições para o nosso número", boleto.Carteira));
+
+                    boleto.NossoNumero = string.Format("{0}{1}", boleto.Cedente.Convenio, Utils.FormatCode(boleto.NossoNumero, 10));
+                }
+                /*
+                 * Convênio de 6 posições
+                 * Nosso Número com 11 posições
+                 */
+                else if (boleto.Cedente.Convenio.ToString().Length == 6)
+                {
+                    //Nosso Número com 17 posições
+                    if ((boleto.Cedente.Codigo.ToString().Length + boleto.NossoNumero.Length) > 11)
+                        throw new NotImplementedException(string.Format("Para a carteira {0}, a quantidade máxima são de 11 de posições para o nosso número. Onde o nosso número é formado por CCCCCCNNNNN-X: C -> número do convênio fornecido pelo Banco, N -> seqüencial atribuído pelo cliente e X -> dígito verificador do “Nosso-Número”.", boleto.Carteira));
+
+                    boleto.NossoNumero = string.Format("{0}{1}", boleto.Cedente.Convenio, Utils.FormatCode(boleto.NossoNumero, 5));
+                }
+                /*
+                  * Convênio de 4 posições
+                  * Nosso Número com 11 posições
+                  */
+                else if (boleto.Cedente.Convenio.ToString().Length == 4)
+                {
+                    if (boleto.NossoNumero.Length > 7)
+                        throw new NotImplementedException(string.Format("Para a carteira {0}, a quantidade máxima são de 7 de posições para o nosso número [{1}]", boleto.Carteira, boleto.NossoNumero));
+
+                    boleto.NossoNumero = string.Format("{0}{1}", boleto.Cedente.Convenio, Utils.FormatCode(boleto.NossoNumero, 7));
+                }
+                else
+                    boleto.NossoNumero = Utils.FormatCode(boleto.NossoNumero, 11);
+            }
+            #endregion Carteira 17-027
 
             #region Carteira 18
             //Carteira 18 com nosso número de 11 posições
@@ -646,6 +690,63 @@ namespace BoletoNet
             }
             #endregion Carteira 17-019
 
+            #region Carteira 17-027
+            if (boleto.Carteira.Equals("17-027"))
+            {
+                if (boleto.Cedente.Convenio.ToString().Length == 7)
+                {
+                    #region Especificação Convênio 7 posições
+                    /*
+                    Posição     Tamanho     Picture     Conteúdo
+                    01 a 03         03      9(3)            Código do Banco na Câmara de Compensação = ‘001’
+                    04 a 04         01      9(1)            Código da Moeda = '9'
+                    05 a 05         01      9(1)            DV do Código de Barras (Anexo 10)
+                    06 a 09         04      9(04)           Fator de Vencimento (Anexo 8)
+                    10 a 19         10      9(08)           V(2) Valor
+                    20 a 25         06      9(6)            Zeros
+                    26 a 42         17      9(17)           Nosso-Número, sem o DV
+                    26 a 32         9       (7)             Número do Convênio fornecido pelo Banco (CCCCCCC)
+                    33 a 42         9       (10)            Complemento do Nosso-Número, sem DV (NNNNNNNNNN)
+                    43 a 44         02      9(2)            Tipo de Carteira/Modalidade de Cobrança
+                     */
+                    #endregion Especificação Convênio 7 posições
+
+                    boleto.CodigoBarra.Codigo = string.Format("{0}{1}{2}{3}{4}{5}{6}",
+                        Utils.FormatCode(Codigo.ToString(), 3),
+                        boleto.Moeda,
+                        FatorVencimento(boleto),
+                        valorBoleto,
+                        "000000",
+                        boleto.NossoNumero,
+                        Utils.FormatCode(LimparCarteira(boleto.Carteira), 2));
+                }
+                else if (boleto.Cedente.Convenio.ToString().Length == 6)
+                {
+                    boleto.CodigoBarra.Codigo = string.Format("{0}{1}{2}{3}{4}{5}{6}{7}",
+                            Utils.FormatCode(Codigo.ToString(), 3),
+                            boleto.Moeda,
+                            FatorVencimento(boleto),
+                            valorBoleto,
+                            boleto.NossoNumero,
+                            boleto.Cedente.ContaBancaria.Agencia,
+                            boleto.Cedente.ContaBancaria.Conta,
+                            LimparCarteira(boleto.Carteira));
+                }
+                else if (boleto.Cedente.Convenio.ToString().Length == 4)
+                {
+                    boleto.CodigoBarra.Codigo = string.Format("{0}{1}{2}{3}{4}{5}{6}{7}",
+                        Utils.FormatCode(Codigo.ToString(), 3),
+                        boleto.Moeda,
+                        FatorVencimento(boleto),
+                        valorBoleto,
+                        boleto.NossoNumero,
+                        boleto.Cedente.ContaBancaria.Agencia,
+                        boleto.Cedente.ContaBancaria.Conta,
+                        LimparCarteira(boleto.Carteira));
+                }
+            }
+            #endregion Carteira 17-027
+
             #region Carteira 18
             if (boleto.Carteira.Equals("18"))
             {
@@ -1031,6 +1132,7 @@ namespace BoletoNet
             switch (boleto.Carteira)
             {
                 case "17-019":
+                case "17-027":
                 case "18-019":
                     boleto.NossoNumero = string.Format("{0}/{1}", LimparCarteira(boleto.Carteira), boleto.NossoNumero);
                     return;
@@ -1240,7 +1342,7 @@ namespace BoletoNet
                 // 2 ou 3 – para carteira 11/17 modalidade Vinculada/Caucionada e carteira 31; 
                 // 4 – para carteira 11/17 modalidade Descontada e carteira 51; 
                 // 7 – para carteira 17 modalidade Simples.
-                if (boleto.Carteira.Equals("17-019"))
+                if (boleto.Carteira.Equals("17-019") || boleto.Carteira.Equals("17-027"))
                     _segmentoP += "7";
                 else
                     _segmentoP += "0";

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -338,7 +338,7 @@ namespace BoletoNet
 
                 //Para carteiras "17-019" e "18-019" do Banco do Brasil, a ficha de compensação não possui código da carteira
                 //na formatação do campo.
-                if (Boleto.Banco.Codigo == 1 & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("18-019")))
+                if (Boleto.Banco.Codigo == 1 & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("17-027") | Boleto.Carteira.Equals("18-019")))
                 {
                     html.Replace("Carteira /", "");
                     html.Replace("@NOSSONUMERO", "@NOSSONUMEROBB");
@@ -585,10 +585,10 @@ namespace BoletoNet
                 .Replace("@DATAPROCESSAMENTO", Boleto.DataProcessamento.ToString("dd/MM/yyyy"))
 
             #region Implementação para o Banco do Brasil
-                //Variável inserida para atender às especificações das carteiras "17-019" e "18-019" do Banco do Brasil
+                //Variável inserida para atender às especificações das carteiras "17-019", "17-027" e "18-019" do Banco do Brasil
                 //apenas para a ficha de compensação.
-                //Como a variável não existirá se não forem as carteiras "17-019" e "18-019", não foi colocado o [if].
-                    .Replace("@NOSSONUMEROBB", Boleto.Banco.Codigo == 1 & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("18-019")) ? Boleto.NossoNumero.Substring(3) : string.Empty)
+                //Como a variável não existirá se não forem as carteiras "17-019", "17-027" e "18-019", não foi colocado o [if].
+                    .Replace("@NOSSONUMEROBB", Boleto.Banco.Codigo == 1 & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("17-027") | Boleto.Carteira.Equals("18-019")) ? Boleto.NossoNumero.Substring(3) : string.Empty)
             #endregion Implementação para o Banco do Brasil
 
 .Replace("@NOSSONUMERO", Boleto.NossoNumero)


### PR DESCRIPTION
O Banco do Brasil liberou o uso da carteira 17 com vairação 027 mas não está disponível na validação do Boleto.Net.