### PR TITLE
[Bradesco] Correção da conversão do Valor do Boleto para string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,5 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+*.dll
+*.pdb

--- a/src/Boleto.Net.MVC/Models/Exemplos.cs
+++ b/src/Boleto.Net.MVC/Models/Exemplos.cs
@@ -192,6 +192,7 @@ namespace Boleto.Net.MVC.Models
             //Carteiras 
             BoletoNet.Boleto b = new BoletoNet.Boleto(vencimento, 1.01m, "09", "01000000001", c);
             b.NumeroDocumento = "01000000001";
+            b.DataVencimento = new DateTime(2015, 09, 12);
 
             b.Sacado = new Sacado("000.000.000-00", "Nome do seu Cliente ");
             b.Sacado.Endereco.End = "Endereço do seu Cliente ";

--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -116,7 +116,7 @@ namespace BoletoNet
             //if (boleto.Carteira == "06" && !Utils.DataValida(boleto.DataVencimento))
             //    FFFF = "0000";
 
-            string VVVVVVVVVV = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+            string VVVVVVVVVV = boleto.ValorBoleto.ToString().Replace(",", "").Replace(".", "");
             VVVVVVVVVV = Utils.FormatCode(VVVVVVVVVV, 10);
 
             //if (Utils.ToInt64(VVVVVVVVVV) == 0)
@@ -148,7 +148,7 @@ namespace BoletoNet
         /// 
         public override void FormataCodigoBarra(Boleto boleto)
         {
-            string valorBoleto = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+            var valorBoleto = boleto.ValorBoleto.ToString().Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
             if (boleto.Carteira == "02" || boleto.Carteira == "03" || boleto.Carteira == "09" || boleto.Carteira == "19")


### PR DESCRIPTION
O campo ValorBoleto estava sendo convertido para string com
ToString("f"), isso faz com que os números fiquem  à esquerda e os zeros
fiquem a direita, o que torna o valor do boleto absurdo como
1.010.000.000.000.