### PR TITLE
Adicionada verificação no Nosso Número do Banco Itaú

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -65,10 +65,18 @@ namespace BoletoNet
                     }
                     throw new NotImplementedException("Carteira não implementada: " + boleto.Carteira + carteirasImplementadas.ToString());
                 }
+
+                //Verifica se o NossoNumero é um inteiro válido.
+                int intNossoNumero;
+                if (!Int32.TryParse(boleto.NossoNumero, out intNossoNumero))
+                    throw new NotImplementedException("Nosso número para a carteira " + boleto.Carteira + " inválido.");
+
                 //Verifica se o tamanho para o NossoNumero são 8 dígitos
-                if (Convert.ToInt32(boleto.NossoNumero).ToString().Length > 8)
-                    throw new NotImplementedException("A quantidade de dígitos do nosso número para a carteira " + boleto.Carteira + ", são 8 números.");
-                else if (Convert.ToInt32(boleto.NossoNumero).ToString().Length < 8)
+                if (boleto.NossoNumero.Length > 8)
+                    throw new NotImplementedException("A quantidade de dígitos do nosso número para a carteira "
+                        + boleto.Carteira + ", são 8 números.");
+
+                if (boleto.NossoNumero.Length < 8)
                     boleto.NossoNumero = Utils.FormatCode(boleto.NossoNumero, 8);
 
                 //É obrigatório o preenchimento do número do documento


### PR DESCRIPTION
Em um dos cenários de teste, quando passou o valor do Nosso Número como uma string vazia, quando a execução chega nesse ponto do código, no formato anterior o 'Convert.ToInt32' cai na exceção de todo esse bloco de código que retorna a mensagem padrão 'Erro ao validar boletos'.

Porém, no meu cenário é interessante tratar esse situação especificamente, verificando se o Nosso Número é um inteiro válido antes de prosseguir, e caso não seja, retornar uma exceção com uma mensagem mais clara de onde está o erro (no caso, no Nosso Número).