### PR TITLE
Tratamento de exceção para convênios do BB

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -687,6 +687,10 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
                 }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
+                }
             }
             #endregion Carteira 17-019
 
@@ -743,6 +747,10 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Agencia,
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
+                }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
                 }
             }
             #endregion Carteira 17-027
@@ -818,6 +826,11 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
                 }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
+                }
+
             }
             #endregion Carteira 18-019
 
@@ -886,6 +899,10 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
                 }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
+                }
             }
             #endregion Carteira 18-027
 
@@ -953,6 +970,10 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
                 }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
+                }
             }
             #endregion Carteira 18-035
 
@@ -1019,6 +1040,10 @@ namespace BoletoNet
                         boleto.Cedente.ContaBancaria.Agencia,
                         boleto.Cedente.ContaBancaria.Conta,
                         LimparCarteira(boleto.Carteira));
+                }
+                else
+                {
+                    throw new Exception("Código do convênio informado é inválido. O código do convenio deve ter 4, 6, ou 7 dígitos.");
                 }
             }
             #endregion Carteira 18-140

--- a/src/Boleto.Net/Util/Extensions.cs
+++ b/src/Boleto.Net/Util/Extensions.cs
@@ -43,19 +43,5 @@ namespace BoletoNet.Util
                 while (e1.MoveNext() && e2.MoveNext())
                     yield return resultSelector(e1.Current, e2.Current);
         }
-
-        public static bool IsNullOrWhiteSpace(String value)
-        {
-            if (value == null) return true;
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (!Char.IsWhiteSpace(value[i])) return false;
-            }
-
-            return true;
-        }
     }
-
-
 }


### PR DESCRIPTION
Tratamento de exceção para convênios do BB.

Quando o código do convênio é informado incorretamente, não existe um tratamento específicio, sendo necessária realizar depuração para encontrar o erro. Foi feito um tratamento para alertar o usuário quanto a este erro.