### PR TITLE
Adicionado Geração do PDF de vários Boletos

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -1204,9 +1204,44 @@ namespace BoletoNet
 
         public byte[] MontaBytesPDF(bool convertLinhaDigitavelToImage = false)
         {
-
             return (new NReco.PdfGenerator.HtmlToPdfConverter()).GeneratePdf(this.MontaHtmlEmbedded(convertLinhaDigitavelToImage, true));
         }
+        
+        /// <summary>
+        /// Lista de Boletos, objetos do tipo
+        /// BoletoBancario
+        /// </summary>
+        /// <param name="boletos">Lista de Boletos, objetos do tipo BoletoBancario</param>
+        /// <param name="tituloNaView">Título Que aparecerá na Aba do Navegador</param>
+        /// <param name="CustomSwitches">Custom WkHtmlToPdf global options</param>
+        /// <param name="tituloPDF">Título No Início do PDF</param>
+        /// <param name="PretoBranco">Preto e Branco = true</param>
+        /// <param name="convertLinhaDigitavelToImage">bool Converter a Linha Digitavel Em Imagem</param>
+        /// <returns>byte[], Vetor de bytes do PDF</returns>
+        public byte[] MontaBytesListaBoletosPDF(List<BoletoBancario> boletos, string tituloNaView = "", string CustomSwitches = "", string tituloPDF = "", bool PretoBranco = false, bool convertLinhaDigitavelToImage = false)
+        {
+            StringBuilder htmlBoletos = new StringBuilder();
+            htmlBoletos.Append("<html><head><title>");
+            htmlBoletos.Append(tituloNaView);
+            htmlBoletos.Append("</title><style type='text/css' media='screen,print'>");
+            htmlBoletos.Append(".break{ display: block; clear: both; page-break-after: always;}");
+            htmlBoletos.Append("</style></head><body>");
+            if (!string.IsNullOrEmpty(tituloPDF))
+            {
+                htmlBoletos.Append("<br/><center><h1>");
+                htmlBoletos.Append(tituloPDF);
+                htmlBoletos.Append("</h1></center><br/>");
+            }
+            foreach (BoletoBancario boleto in boletos)
+            {
+                htmlBoletos.Append("<div class='break'>");
+                htmlBoletos.Append(boleto.MontaHtmlEmbedded(convertLinhaDigitavelToImage, true));
+                htmlBoletos.Append("</div>");
+            }
+            htmlBoletos.Append("</body></html>");
+            return (new NReco.PdfGenerator.HtmlToPdfConverter() { CustomWkHtmlArgs = CustomSwitches, Grayscale = PretoBranco }).GeneratePdf(htmlBoletos.ToString());
+        }
+        
         #endregion Geração do Html OffLine
 
         public System.Drawing.Image GeraImagemCodigoBarras(Boleto boleto)


### PR DESCRIPTION
Use o método :

`MontaBytesListaBoletosPDF()    ` 

Passando uma lista de objetos do tipo `BoletoBancario` receba devolta um `byte[]` com `PDF` já pronto para download ou salvamento do arquivo, observe que o método é bem simples, e tem umas opções
a mais:  `CustomSwitches` pode ser visto em [wkhtmltopdf Manual](http://wkhtmltopdf.org/usage/wkhtmltopdf.txt)
`tituloPDF` insere um título na primeira página dos boletos,
`PretoBranco` tipo de impressão, preto e branco ou colorido.


```
 byte[] PdfBytes = new BoletoBancario().MontaBytesListaBoletosPDF(Boletos, "Boletos Bancários", CustomSwitches, "Boletos Bancários");
```

**## Mais instruções  de uso no final do Issue:**  #165

