### PR TITLE
Melhoria: Permitir utilizar construtor sem ter que atribuir digito = ""

### DIFF
--- a/src/Boleto.Net/Util/Utils.cs
+++ b/src/Boleto.Net/Util/Utils.cs
@@ -355,11 +355,11 @@ namespace BoletoNet
             try
             {
                 agenciaConta = agencia;
-                if (digitoAgencia != string.Empty)
+                if (!string.IsNullOrEmpty(digitoAgencia))
                     agenciaConta += "-" + digitoAgencia;
 
                 agenciaConta += "/" + conta;
-                if (digitoConta != string.Empty)
+                if (!string.IsNullOrEmpty(digitoConta))
                     agenciaConta += "-" + digitoConta;
 
                 return agenciaConta;


### PR DESCRIPTION
**new Cedente(cedenteCNPJ, cedenteNome, cedenteAgencia, cedenteConta)**
esse construtor faz com que os digitos sejam nulos e falhem naquelas verificações da classe Utils. Então no boleto vai sair algo parecido com: 0123-/...