### PR TITLE
Boleto BNB nº da carteira para cod da operação

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Nordeste.cs
+++ b/src/Boleto.Net/Banco/Banco_Nordeste.cs
@@ -49,7 +49,9 @@ namespace BoletoNet
         {
 
             if (string.IsNullOrEmpty(boleto.Carteira))
-                throw new NotImplementedException("Carteira não informada. Utilize a carteira 4, 5, 6, I.");
+                throw new NotImplementedException("Carteira não informada. Utilize a carteira 4, 5, 6, I ou Tipo de Operação 21, 41, 31, 51");
+
+            boleto.Carteira = FormataCarteira(boleto.Carteira);//Transforma de Carteira para Tipo de Operacao. Ex.: de '4' para '21'
 
             boleto.QuantidadeMoeda = 0;
 
@@ -359,6 +361,15 @@ namespace BoletoNet
                 case "I"://Cobranca Simplificada(Sem Registro)
                     return "51";
                     break;
+
+                //Caso esteja usando o tipo de operacao
+                case "21":
+                case "41":
+                case "31":
+                case "51":
+                    return carteira;
+                    break;
+
                 default:
                     throw new Exception("Carteira nao implementada");
                     break;


### PR DESCRIPTION
A equipe de homologação do BNB solicitou a alteração do número da carteira para código da operação na exibição da carteira no boleto. Onde a carteira 4 passará a ser exibida o código de operação equivalente que é 21.