### PR TITLE
Banco do Brasil - Modalidade de Cobrança por boleto

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -1368,10 +1368,14 @@ namespace BoletoNet
                 // 2 ou 3 – para carteira 11/17 modalidade Vinculada/Caucionada e carteira 31; 
                 // 4 – para carteira 11/17 modalidade Descontada e carteira 51; 
                 // 7 – para carteira 17 modalidade Simples.
-                if (boleto.Carteira.Equals("17-019") || boleto.Carteira.Equals("17-027"))
-                    _segmentoP += "7";
-                else
-                    _segmentoP += "0";
+                if (boleto.ModalidadeCobranca == 0) {
+                    if (boleto.Carteira.Equals("17-019") || boleto.Carteira.Equals("17-027"))
+                        _segmentoP += "7";
+                    else
+                        _segmentoP += "0";
+                } else {
+                    _segmentoP += boleto.ModalidadeCobranca.ToString();
+                }
 
                 // Campo não tratado pelo BB. Forma de cadastramento do título no banco. Pode ser branco/espaço, 0, 1=cobrança registrada, 2=sem registro.
                 _segmentoP += "1";

--- a/src/Boleto.Net/Boleto/Boleto.cs
+++ b/src/Boleto.Net/Boleto/Boleto.cs
@@ -60,6 +60,7 @@ namespace BoletoNet
 		private DateTime _dataOutrosAcrescimos;
 		private DateTime _dataOutrosDescontos;
 		private short _percentualIOS;
+        private short _modalidadeCobranca = 0;
 
 		private string _tipoModalidade = string.Empty;
 		private Remessa _remessa;
@@ -515,10 +516,19 @@ namespace BoletoNet
 			set { this._percentualIOS = value; }
 		}
 
-		/// <summary>
-		/// Retorna os Parâmetros utilizados na geração da Remessa para o Boleto
-		/// </summary>
-		public Remessa Remessa
+        /// <summary> 
+        /// C006 - Retorna a modalidade de cobrança/código carteira 1-Cobrança Simples 2-Cobrança Vinculada 3-Cobrança Caucionada 4-Cobrança Descontada 5-Cobrança Vendor 
+        /// </summary>
+        public short ModalidadeCobranca
+        {
+            get { return this._modalidadeCobranca; }
+            set { this._modalidadeCobranca = value; }
+        }
+
+        /// <summary>
+        /// Retorna os Parâmetros utilizados na geração da Remessa para o Boleto
+        /// </summary>
+        public Remessa Remessa
 		{
 			get { return this._remessa; }
 			set { this._remessa = value; }


### PR DESCRIPTION
Implementado seguindo a ideia proposta https://github.com/BoletoNet/boletonet/issues/253 para abrir a possibilidade de definir por boleto a Modalidade de Cobrança que pode variar na mesma carteira por exemplo a 17

1 – para carteira 11/12 na modalidade Simples;
2 ou 3 – para carteira 11/17 modalidade Vinculada/Caucionada e carteira 31;
4 – para carteira 11/17 modalidade Descontada e carteira 51; 
7 – para carteira 17 modalidade Simples.