### PR TITLE
Alterado limite de digitos cedente banco SANTANDER

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Santander.cs
+++ b/src/Boleto.Net/Banco/Banco_Santander.cs
@@ -225,8 +225,9 @@ namespace BoletoNet
                 if (boleto.NossoNumero.Length != 12)
                     throw new NotSupportedException("Nosso Número deve ter 12 posições para o banco 033.");
             }
-            if (boleto.Cedente.Codigo.ToString().Length > 7)
-                throw new NotImplementedException("Código cedente deve ter 7 posições.");
+
+            if (boleto.Cedente.Codigo.ToString().Length > 8)
+                throw new NotImplementedException("Código cedente deve ter 8 posições.");
 
             // Atribui o nome do banco ao local de pagamento
 			if (string.IsNullOrEmpty(boleto.LocalPagamento))


### PR DESCRIPTION
Alterado para 8 o limite de dígitos máximo da conta do cedente do banco SANTANDER. Visto que segundo manual, o limite de dígitos da conta é 8.