### PR TITLE
Possibilitar ao boleto.net a criação e configuração do pedido de baixa do Banco Itaú

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -1097,7 +1097,7 @@ namespace BoletoNet
                 // para títulos que já estão no banco, portanto o campo será preenchido com zeros.
                 _detalhe += "0000";
 
-                _detalhe += nrDocumento; // Utils.FitStringLength(boleto.NumeroDocumento, 25, 25, ' ', 0, true, true, false); //Identificação do título na empresa
+                _detalhe += Utils.FitStringLength(boleto.NumeroDocumento, 25, 25, ' ', 0, true, true, false); //Identificação do título na empresa
                 _detalhe += Utils.FitStringLength(boleto.NossoNumero, 8, 8, '0', 0, true, true, true);
                 // Quantidade de moeda variável - Preencher com zeros se a moeda for REAL
                 // O manual do Banco ITAÚ não diz como preencher caso a moeda não seja o REAL
@@ -1110,7 +1110,10 @@ namespace BoletoNet
                 if (boleto.Moeda == 9)
                     _detalhe += "I"; //O código da carteira só muda para dois tipos, quando a cobrança for em dólar
 
-                _detalhe += "01"; // Identificação da ocorrência - 01 REMESSA
+                if (boleto.Remessa != null) // Identificação da ocorrência - 02 PEDIDO DE BAIXA
+                    _detalhe += boleto.Remessa.CodigoOcorrencia;
+                else
+                    _detalhe += "01"; // Identificação da ocorrência - 01 REMESSA
                 _detalhe += Utils.FitStringLength(boleto.NumeroDocumento, 10, 10, ' ', 0, true, true, false);
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
                 _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -646,9 +646,12 @@ namespace BoletoNet
                         agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 6));
                 }
                 else if (Boleto.Banco.Codigo == 399)
-                    //agenciaCodigoCedente = Utils.FormatCode(Cedente.Codigo.ToString(), 7); -> para Banco HSBC mostra apenas código Cedente - por Ponce em 08/06/2012
-                    agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Cedente.Codigo.ToString()); //Solicitação do HSBC que mostrasse agencia/Conta - por Transis em 24/02/15
-
+                { // para Banco HSBC mostra apenas código Cedente - por Ponce em 08/06/2012
+                    if (Boleto.Carteira == "CNR")
+                        agenciaCodigoCedente = Utils.FormatCode(Cedente.Codigo.ToString(), 7);
+                    else  // para Banco HSBC CSB mosrtra também a agência - por Eduardo Chagas em 24/04/2015
+                        agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 7));
+                }
                 else if (Boleto.Banco.Codigo == 748)
                     agenciaCodigoCedente = string.Format("{0}.{1}.{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.OperacaConta, Cedente.Codigo);
                 else

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -646,12 +646,8 @@ namespace BoletoNet
                         agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 6));
                 }
                 else if (Boleto.Banco.Codigo == 399)
-                { // para Banco HSBC mostra apenas código Cedente - por Ponce em 08/06/2012
-                    if (Boleto.Carteira == "CNR")
-                        agenciaCodigoCedente = Utils.FormatCode(Cedente.Codigo.ToString(), 7);
-                    else  // para Banco HSBC CSB mosrtra também a agência - por Eduardo Chagas em 24/04/2015
-                        agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 7));
-                }
+                    //agenciaCodigoCedente = Utils.FormatCode(Cedente.Codigo.ToString(), 7); -> para Banco HSBC mostra apenas código Cedente - por Ponce em 08/06/2012
+                    agenciaCodigoCedente = String.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 7)); //Solicitação do HSBC que mostrasse agencia/Conta - por Transis em 24/02/15
                 else if (Boleto.Banco.Codigo == 748)
                     agenciaCodigoCedente = string.Format("{0}.{1}.{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.OperacaConta, Cedente.Codigo);
                 else


### PR DESCRIPTION
Possibilitar ao boleto.net a criação e configuração do pedido de baixa do Banco Itaú
Revisions 12825, 12826 e 12829.
Correção da geração da remessa do CNAB 109 do Itaú, para gerar o codigo identificador na empresa.