### PR TITLE
Hsbc

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
@@ -56,6 +56,7 @@ namespace BoletoNet
                 decimal vltitulostotal = 0;                 //Uso apenas no registro TRAILER do banco Santander - jsoda em 09/05/2012 - Add no registro TRAILER do banco Banrisul - sidneiklein em 08/08/2013
 
                 StreamWriter incluiLinha = new StreamWriter(arquivo, Encoding.GetEncoding("ISO-8859-1"));
+                cedente.Carteira = boletos[0].Carteira;
                 strline = banco.GerarHeaderRemessa(numeroConvenio, cedente, TipoArquivo.CNAB400, numeroArquivoRemessa);
                 incluiLinha.WriteLine(strline);
 
@@ -76,7 +77,12 @@ namespace BoletoNet
                             numeroRegistro++;
                         }
                     }
-
+                    if ((boleto.Instrucoes != null && boleto.Instrucoes.Count > 0) || (boleto.Sacado.Instrucoes != null && boleto.Sacado.Instrucoes.Count > 0))
+                    {
+                        strline = boleto.Banco.GerarMensagemVariavelRemessa(boleto, ref numeroRegistro, TipoArquivo.CNAB400);
+                        if (!string.IsNullOrEmpty(strline) && !string.IsNullOrWhiteSpace(strline))
+                            incluiLinha.WriteLine(strline);
+                    }
                 }
 
                 strline = banco.GerarTrailerRemessa(numeroRegistro, TipoArquivo.CNAB400, cedente, vltitulostotal);

--- a/src/Boleto.Net/Banco/AbstractBanco.cs
+++ b/src/Boleto.Net/Banco/AbstractBanco.cs
@@ -98,6 +98,13 @@ namespace BoletoNet
             string _remessa = "";
             return _remessa;
         }
+        /// Gera registros de Mensagem Variavel do arquivo remessa
+        /// </summary>
+        public virtual string GerarMensagemVariavelRemessa(Boleto boleto, ref int numeroRegistro, TipoArquivo tipoArquivo)
+        {
+            string _remessa = "";
+            return _remessa;
+        }
         /// <summary>
         /// Gera os registros de Trailer do arquivo de remessa
         /// </summary>

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -1503,6 +1503,8 @@ namespace BoletoNet
                     detalhe.MotivosRejeicao = this.MotivosRejeicaoCSB(registro.Substring(301, 2));
                     detalhe.DataOcorrencia = Utils.ToDateTime(dataOcorrencia.ToString("##-##-##"));
                     detalhe.NumeroDocumento = registro.Substring(116, 10);
+                    if (detalhe.NumeroDocumento.Contains("-"))
+                        detalhe.NumeroDocumento = detalhe.NumeroDocumento.Substring(0, detalhe.NumeroDocumento.LastIndexOf('-'));
                     detalhe.NossoNumero = registro.Substring(126, 10);
                     detalhe.DataVencimento = Utils.ToDateTime(dataVencimento.ToString("##-##-##"));
                     decimal valorTitulo = Convert.ToInt64(registro.Substring(152, 13));
@@ -1538,6 +1540,8 @@ namespace BoletoNet
                     detalhe.CodigoOcorrencia = Utils.ToInt32(registro.Substring(108, 2));
                     detalhe.DataOcorrencia = Utils.ToDateTime(dataOcorrencia.ToString("##-##-##"));
                     detalhe.NumeroDocumento = registro.Substring(116, 6);
+                    if (detalhe.NumeroDocumento.Contains("-"))
+                        detalhe.NumeroDocumento = detalhe.NumeroDocumento.Substring(0, detalhe.NumeroDocumento.LastIndexOf('-'));
                     detalhe.DataVencimento = Utils.ToDateTime(dataVencimento.ToString("##-##-##"));
                     decimal valorTitulo = Convert.ToInt64(registro.Substring(152, 11));
                     detalhe.ValorTitulo = valorTitulo / 100;

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -421,9 +421,9 @@ namespace BoletoNet
 
                     case TipoArquivo.CNAB400:
                         if (cedente.Carteira == "1")
-                            _header = GerarHeaderRemessaCNAB400CSB(0, cedente);
+                            _header = GerarHeaderRemessaCNAB400CSB(numeroConvenio, cedente);
                         else
-                            _header = GerarHeaderRemessaCNAB400CNR(0, cedente);
+                            _header = GerarHeaderRemessaCNAB400CNR(numeroConvenio, cedente);
                         break;
                     case TipoArquivo.Outro:
                         throw new Exception("Tipo de arquivo inexistente.");
@@ -544,7 +544,7 @@ namespace BoletoNet
             }
         }
 
-        private string GerarHeaderRemessaCNAB400CSB(int numeroConvenio, Cedente cedente)
+        private string GerarHeaderRemessaCNAB400CSB(string numeroConvenio, Cedente cedente)
         {
             try
             {
@@ -642,13 +642,13 @@ namespace BoletoNet
                 switch (tipoArquivo)
                 {
                     case TipoArquivo.CNAB240:
+                        _detalhe = GerarDetalheRemessaCNAB240();
+                        break;
+                    case TipoArquivo.CNAB400:
                         if (boleto.Carteira == "1")
                             _detalhe = GerarDetalheRemessaCNAB400CSB(boleto, numeroRegistro, tipoArquivo);
                         else
                             _detalhe = GerarDetalheRemessaCNAB400CNR(boleto, numeroRegistro, tipoArquivo);
-                        break;
-                    case TipoArquivo.CNAB400:
-                        _detalhe = GerarDetalheRemessaCNAB400(boleto, numeroRegistro, tipoArquivo);
                         break;
                     case TipoArquivo.Outro:
                         throw new Exception("Tipo de arquivo inexistente.");

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -833,7 +833,7 @@ namespace BoletoNet
                 _detalhe += Utils.FitStringLength(boleto.NumeroDocumento, 25, 25, ' ', 0, true, true, false); 
 
                 //Nosso Número==> 063 - 073
-                _detalhe += Utils.FitStringLength(boleto.NossoNumero + Mod11(boleto.NossoNumero, 7).ToString(), 11, 11, '0', 0, true, true, false);
+                _detalhe += Utils.FitStringLength(boleto.NossoNumero + Mod11Hsbc(boleto.NossoNumero, 7).ToString(), 11, 11, '0', 0, true, true, false);
 
                 if (boleto.OutrosDescontos > 0)
                 {

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -1500,7 +1500,7 @@ namespace BoletoNet
                     detalhe.MotivosRejeicao = this.MotivosRejeicaoCSB(registro.Substring(301, 2));
                     detalhe.DataOcorrencia = Utils.ToDateTime(dataOcorrencia.ToString("##-##-##"));
                     detalhe.NumeroDocumento = registro.Substring(116, 10);
-                    detalhe.NossoNumero = registro.Substring(126, 11);
+                    detalhe.NossoNumero = registro.Substring(126, 10);
                     detalhe.DataVencimento = Utils.ToDateTime(dataVencimento.ToString("##-##-##"));
                     decimal valorTitulo = Convert.ToInt64(registro.Substring(152, 13));
                     detalhe.ValorTitulo = valorTitulo / 100;
@@ -1530,7 +1530,7 @@ namespace BoletoNet
                     detalhe.Conta = Utils.ToInt32(registro.Substring(24, 11));
                     detalhe.UsoEmpresa = registro.Substring(37, 16);
                     detalhe.NossoNumeroComDV = registro.Substring(62, 16);
-                    detalhe.NossoNumero = registro.Substring(62, 16); //Sem o DV
+                    detalhe.NossoNumero = registro.Substring(62, 15); //Sem o DV
                     detalhe.Carteira = registro.Substring(107, 1);
                     detalhe.CodigoOcorrencia = Utils.ToInt32(registro.Substring(108, 2));
                     detalhe.DataOcorrencia = Utils.ToDateTime(dataOcorrencia.ToString("##-##-##"));

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -895,6 +895,9 @@ namespace BoletoNet
                     case "4": //DuplicataServico
                         _detalhe += "10";
                         break;
+                    case "98":  //Cobrança com emissão total do bloqueto pelo cliente
+                        _detalhe += "98"; //Cobrança com emissão total do bloqueto pelo cliente
+                        break;
                 }
 
                 //Aceite ==> 150 - 150

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -420,7 +420,7 @@ namespace BoletoNet
                 {
 
                     case TipoArquivo.CNAB400:
-                        if (cedente.Carteira == "1")
+                        if (cedente.Carteira == "1" || cedente.Carteira == "3" || cedente.Carteira == "4")
                             _header = GerarHeaderRemessaCNAB400CSB(numeroConvenio, cedente);
                         else
                             _header = GerarHeaderRemessaCNAB400CNR(numeroConvenio, cedente);
@@ -645,7 +645,7 @@ namespace BoletoNet
                         _detalhe = GerarDetalheRemessaCNAB240();
                         break;
                     case TipoArquivo.CNAB400:
-                        if (boleto.Carteira == "1")
+                        if (boleto.Carteira == "1" || boleto.Carteira == "3" || boleto.Carteira == "4")
                             _detalhe = GerarDetalheRemessaCNAB400CSB(boleto, numeroRegistro, tipoArquivo);
                         else
                             _detalhe = GerarDetalheRemessaCNAB400CNR(boleto, numeroRegistro, tipoArquivo);

--- a/src/Boleto.Net/Banco/IBanco.cs
+++ b/src/Boleto.Net/Banco/IBanco.cs
@@ -106,6 +106,10 @@ namespace BoletoNet
         /// Gera o Trailer de lote do arquivo de remessa
         /// </summary>
         string GerarTrailerLoteRemessa(int numeroRegistro, Boleto boletos);
+        /// <summary>
+        /// Gera os registros de Mensagem Variavel do arquivo de remessa
+        /// </summary>
+        string GerarMensagemVariavelRemessa(Boleto boleto, ref int numeroRegistro, TipoArquivo tipoArquivo);
 
         DetalheSegmentoTRetornoCNAB240 LerDetalheSegmentoTRetornoCNAB240(string registro);
 

--- a/src/Boleto.Net/Boleto.Net.csproj
+++ b/src/Boleto.Net/Boleto.Net.csproj
@@ -19,7 +19,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/Boleto.Net/Boleto/Cedente.cs
+++ b/src/Boleto.Net/Boleto/Cedente.cs
@@ -13,7 +13,7 @@ namespace BoletoNet
         private string _cpfcnpj;
         private string _nome;
         private ContaBancaria _contaBancaria;
-        private int _convenio = 0;
+        private long _convenio = 0;
         private int _numeroSequencial;
         private int _numeroBordero;
         private int _digitoCedente = -1;
@@ -174,7 +174,7 @@ namespace BoletoNet
         /// <summary>
         /// Número do Convênio
         /// </summary>
-        public int Convenio
+        public long Convenio
         {
             get
             {
@@ -182,7 +182,7 @@ namespace BoletoNet
             }
             set
             {
-                _convenio = value;
+                _convenio = Convert.ToInt64(value);
             }
         }
 

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_HSBC.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_HSBC.cs
@@ -32,6 +32,7 @@ namespace BoletoNet
         ParcelaConsorcio = 22, //PC –  PARCELA DE CONSÓRCIO
         NotaFiscal = 23, //NF-Nota Fiscal
         DocumentoDivida = 24, //DD-Documento de Dívida
+        CobrancaEmissaoCliente = 98,
         Outros = 99, //Outros
         PD = 0
     }
@@ -97,6 +98,7 @@ namespace BoletoNet
                 case EnumEspecieDocumento_HSBC.ParcelaConsorcio: return "22";
                 case EnumEspecieDocumento_HSBC.NotaFiscal: return "23";
                 case EnumEspecieDocumento_HSBC.DocumentoDivida: return "24";
+                case EnumEspecieDocumento_HSBC.CobrancaEmissaoCliente: return "98";
                 case EnumEspecieDocumento_HSBC.Outros: return "99";
                 case EnumEspecieDocumento_HSBC.PD: return "0";
                 default: return "99";
@@ -132,6 +134,7 @@ namespace BoletoNet
                 case "22": return EnumEspecieDocumento_HSBC.ParcelaConsorcio;
                 case "23": return EnumEspecieDocumento_HSBC.NotaFiscal;
                 case "24": return EnumEspecieDocumento_HSBC.DocumentoDivida;
+                case "98": return EnumEspecieDocumento_HSBC.CobrancaEmissaoCliente;
                 case "99": return EnumEspecieDocumento_HSBC.Outros;
                 case "0": return EnumEspecieDocumento_HSBC.PD;
                 default: return EnumEspecieDocumento_HSBC.Outros;
@@ -270,6 +273,11 @@ namespace BoletoNet
                         this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_HSBC.Outros);
                         this.Especie = "OUTROS";
                         this.Sigla = "OUTROS";
+                        break;
+                    case EnumEspecieDocumento_HSBC.CobrancaEmissaoCliente:
+                        this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_HSBC.CobrancaEmissaoCliente);
+                        this.Especie = "COBRANÇA COM EMISSÃO TOTAL DO BLOQUETO PELO CLIENTE";
+                        this.Sigla = "PD";
                         break;
                     case EnumEspecieDocumento_HSBC.PD:
                         this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_HSBC.PD);

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -631,6 +631,9 @@ namespace BoletoNet
                     case 1:
                         agenciaCodigoCedente = string.Format("{0}-{1}/{2}-{3}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Utils.FormatCode(Cedente.ContaBancaria.Conta, 6), Cedente.ContaBancaria.DigitoConta);
                         break;
+                    case 399:
+                        agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString() + Cedente.DigitoCedente.ToString(), 7));
+                        break;
                     default:
                         agenciaCodigoCedente = string.Format("{0}/{1}-{2}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo.ToString(), 6), Cedente.DigitoCedente.ToString());
                         break;


### PR DESCRIPTION
Remessa do CNAB 400 HSBC (CNR e CSB)
Criação da linha para pedido de baixa HSBC Carteira 1
Inclusão das Ocorrências HSBC
Inclusão das Carteiras 3 e 4
Inclusão da Espécie de Documento - CobrancaEmissaoCliente = 98
Correções de erros no boleto e remessa HSBC:
- Correção de erro ao imprimir o boleto HSBC - CBS - Com registro - Imp. O erro ocorria, pois colocando o código do cliente mais 2 dígitos, estourava o inteiro. Modificado para long.
- No banco HSBC o código do beneficiário deverá ser o número da conta corrente com o dígito e a remessa não está preenchendo a linha de detalhe com a espécie.
- No boleto do HSBC, o código do beneficiário deve ter apenas 6 números, está com 7 e um traço (-) separando o dígito.
- Tirando o dígito verificador do seu número do HSBC da remessa.