### PR TITLE
Refatoração: Removendo virgula dos decimais

### DIFF
--- a/src/Boleto.Net/Banco/Banco_BankBoston.cs
+++ b/src/Boleto.Net/Banco/Banco_BankBoston.cs
@@ -260,7 +260,7 @@ namespace BoletoNet
                 _detalhe += "01";
                 _detalhe += Utils.FitStringLength(boleto.NumeroDocumento, 10, 10, ' ', 0, true, true, false);
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
-                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 _detalhe += "479     ";
                 _detalhe += boleto.EspecieDocumento.Sigla;
                 _detalhe += "N";
@@ -275,11 +275,11 @@ namespace BoletoNet
                     else
                         _detalhe += "00";
                 }
-                _detalhe += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
-                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
-                _detalhe += Utils.FitStringLength(boleto.IOF.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
-                _detalhe += Utils.FitStringLength(boleto.Abatimento.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.IOF.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.Abatimento.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 if (boleto.Sacado.CPFCNPJ.Length > 11)
                     _detalhe += "01";  // CPF
                 else

--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -720,7 +720,7 @@ namespace BoletoNet
                 if (boleto.PercMulta > 0)
                 {
                     _detalhe += "2";
-                    _detalhe += Utils.FitStringLength(boleto.PercMulta.ToString("0.00").Replace(",", ""), 4, 4, '0', 0, true, true, true); //Percentual Multa 9(2)V99 - (04)
+                    _detalhe += Utils.FitStringLength(boleto.PercMulta.ApenasNumeros(), 4, 4, '0', 0, true, true, true); //Percentual Multa 9(2)V99 - (04)
                 }
                 else
                 {
@@ -788,7 +788,7 @@ namespace BoletoNet
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy"); //Data do Vencimento do Título (10, N) DDMMAA
 
                 //Valor do Título (13, N)
-                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 _detalhe += "000"; //Banco Encarregado da Cobrança (3, N)
                 _detalhe += "00000"; //Agência Depositária (5, N)
@@ -853,7 +853,7 @@ namespace BoletoNet
                 //
 
                 // Valor a ser cobrado por Dia de Atraso (13, N)
-                _detalhe += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Data Limite P/Concessão de Desconto (06, N)
 				//if (boleto.DataDesconto.ToString("dd/MM/yyyy") == "01/01/0001")
@@ -867,13 +867,13 @@ namespace BoletoNet
                 }
 
                 //Valor do Desconto (13, N)
-                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Valor do IOF (13, N)
-                _detalhe += Utils.FitStringLength(boleto.IOF.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.IOF.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Valor do Abatimento a ser concedido ou cancelado (13, N)
-                _detalhe += Utils.FitStringLength(boleto.Abatimento.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.Abatimento.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 /*Identificação do Tipo de Inscrição do Sacado (02, N)
                 *01-CPF

--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -1512,7 +1512,7 @@ namespace BoletoNet
                 _segmentoP += "2";
                 _segmentoP += Utils.FitStringLength(boleto.NumeroDocumento, 15, 15, ' ', 0, true, true, false);
                 _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
-                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 _segmentoP += "00000 ";
                 _segmentoP += Utils.FitStringLength(boleto.EspecieDocumento.Codigo.ToString(), 2, 2, '0', 0, true, true, true);
                 _segmentoP += "N";
@@ -1522,7 +1522,7 @@ namespace BoletoNet
                 {
                     _segmentoP += "1";
                     _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
-                    _segmentoP += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoP += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else if (boleto.JurosPermanente)
                 {
@@ -1541,7 +1541,7 @@ namespace BoletoNet
                 {
                     _segmentoP += "1";
                     _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
-                    _segmentoP += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoP += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else
                     _segmentoP += "000000000000000000000000";
@@ -1683,9 +1683,9 @@ namespace BoletoNet
 
                 // Multa em Percentual (%), Valor (R$)
                 if (boleto.PercMulta > 0) {
-                    _segmentoR += Utils.FitStringLength(boleto.PercMulta.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoR += Utils.FitStringLength(boleto.PercMulta.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 } else {
-                    _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
 
                 _segmentoR += _brancos110;

--- a/src/Boleto.Net/Banco/Banco_HSBC.cs
+++ b/src/Boleto.Net/Banco/Banco_HSBC.cs
@@ -719,7 +719,7 @@ namespace BoletoNet
                 _detalhe += boleto.DataVencimento.ToString("ddMMyyyy");
 
                 //Valor da parcela ==> 129 - 140
-                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 12, 12, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 12, 12, '0', 0, true, true, true);
 
                 //Banco cobrador ==> 141 - 143
                 _detalhe += Utils.FitStringLength(boleto.Banco.Codigo.ToString(), 3, 3, '0', 0, true, true, true);

--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -789,7 +789,7 @@ namespace BoletoNet
                 _segmentoP += Utils.FitStringLength(boleto.NumeroDocumento, 10, 10, ' ', 0, true, true, false);
                 _segmentoP += "     ";
                 _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
-                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 _segmentoP += "00000";
                 _segmentoP += " ";
                 _segmentoP += "01";
@@ -797,7 +797,7 @@ namespace BoletoNet
                 _segmentoP += Utils.FitStringLength(boleto.DataDocumento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
                 _segmentoP += "0";
                 _segmentoP += Utils.FitStringLength(boleto.DataJurosMora.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
-                _segmentoP += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                _segmentoP += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 _segmentoP += "0";
                 _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
                 _segmentoP += Utils.FitStringLength("0", 15, 15, '0', 0, true, true, true);
@@ -910,7 +910,7 @@ namespace BoletoNet
                 }
 
                 _segmentoR += Utils.FitStringLength(boleto.DataMulta.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
-                _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 _segmentoR += _brancos110;
                 _segmentoR += "0000000000000000"; //16 zeros
                 _segmentoR += " "; //1 branco
@@ -1113,7 +1113,7 @@ namespace BoletoNet
                 _detalhe += "01"; // Identificação da ocorrência - 01 REMESSA
                 _detalhe += Utils.FitStringLength(boleto.NumeroDocumento, 10, 10, ' ', 0, true, true, false);
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
-                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 _detalhe += "341";
                 _detalhe += "00000"; // Agência onde o título será cobrado - no arquivo de remessa, preencher com ZEROS
 
@@ -1155,11 +1155,11 @@ namespace BoletoNet
                 //Caso seja expresso em moeda variável, deverá ser preenchido com cinco casas decimais.
 
                 //_detalhe += "0000000000000";
-                _detalhe += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 // Data limite para desconto
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
-                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 _detalhe += "0000000000000"; // Valor do IOF
                 _detalhe += "0000000000000"; // Valor do Abatimento
 

--- a/src/Boleto.Net/Banco/Banco_Santander.cs
+++ b/src/Boleto.Net/Banco/Banco_Santander.cs
@@ -774,7 +774,7 @@ namespace BoletoNet
                 _segmentoP += boleto.DataVencimento.ToString("ddMMyyyy");
 
                 //Valor nominal do título ==> 086 - 100
-                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
 
                 //Agência encarregada da cobrança ==> 101 - 104
                 _segmentoP += "0000";
@@ -803,7 +803,7 @@ namespace BoletoNet
                     _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
 
                     //Valor da mora/dia ou Taxa mensal ==> 127 - 141
-                    _segmentoP += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoP += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else
                 {
@@ -826,7 +826,7 @@ namespace BoletoNet
                     _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
 
                     //Valor ou Percentual do desconto concedido ==> 151 - 165
-                    _segmentoP += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoP += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else
                     _segmentoP += "0".PadLeft(24, '0');
@@ -1019,7 +1019,7 @@ namespace BoletoNet
                     _segmentoR += boleto.DataOutrosDescontos.ToString("ddMMyyyy");
 
                     //Valor/Percentual a ser concedido ==> 027 - 041
-                    _segmentoR += Utils.FitStringLength(boleto.OutrosDescontos.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoR += Utils.FitStringLength(boleto.OutrosDescontos.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else
                 {
@@ -1045,7 +1045,7 @@ namespace BoletoNet
                     _segmentoR += boleto.DataMulta.ToString("ddMMyyyy");
 
                     //Valor/Percentual a ser aplicado ==> 075 - 089
-                    _segmentoR += Utils.FitStringLength(boleto.PercMulta.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoR += Utils.FitStringLength(boleto.PercMulta.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else if (boleto.ValorMulta > 0)
                 {
@@ -1056,7 +1056,7 @@ namespace BoletoNet
                     _segmentoR += boleto.DataMulta.ToString("ddMMyyyy");
 
                     //Valor/Percentual a ser aplicado ==> 075 - 089
-                    _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ToString("0.00").Replace(",", ""), 15, 15, '0', 0, true, true, true);
+                    _segmentoR += Utils.FitStringLength(boleto.ValorMulta.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
                 else
                 {
@@ -1272,7 +1272,7 @@ namespace BoletoNet
                     _detalhe += "4";
 
                 //Percentual multa por atraso % ==> 079 - 082
-                _detalhe += Utils.FitStringLength(boleto.PercMulta.ToString("0.00").Replace(",", ""), 4, 4, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.PercMulta.ApenasNumeros(), 4, 4, '0', 0, true, true, true);
                 //Unidade de valor moeda corrente ==> 083 - 084
                 _detalhe += "00";
 
@@ -1325,7 +1325,7 @@ namespace BoletoNet
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
 
                 //Valor do título - moeda corrente ==> 127 - 139
-                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Número do Banco cobrador ==> 140 - 142
                 _detalhe += "033";
@@ -1399,13 +1399,13 @@ namespace BoletoNet
                     _detalhe += "00"; //Não há instruções
 
                 //Valor de mora a ser cobrado por dia de atraso == > 161 - 173
-                _detalhe += Utils.FitStringLength(boleto.JurosMora.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Data limite para concessão de desconto ==> 174 - 179
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
 
                 //Valor de desconto a ser concedido ==> 180 - 192
-                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _detalhe += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
                 
                 //Valor do IOF a ser recolhido pelo Banco para nota de seguro ==> 192 - 205
                 _detalhe += "0000000000000";
@@ -1757,7 +1757,7 @@ namespace BoletoNet
                 _trailer += Utils.FitStringLength(numeroRegistro.ToString(), 6, 6, '0', 0, true, true, true);
 
                 //Valor total dos títulos ==> 008 - 020
-                _trailer += Utils.FitStringLength(vltitulostotal.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true);
+                _trailer += Utils.FitStringLength(vltitulostotal.ApenasNumeros(), 13, 13, '0', 0, true, true, true);
 
                 //Zeros ==> 021 - 394
                 _trailer += complemento;

--- a/src/Boleto.Net/Banco/Banco_Sicoob.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicoob.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Web.UI;
+using BoletoNet.Util;
 
 [assembly: WebResource("BoletoNet.Imagens.756.jpg", "image/jpg")]
 namespace BoletoNet
@@ -446,7 +447,7 @@ namespace BoletoNet
                 _detalhe.Append("01"); //Posição 109 a 110 - REGISTRO DE TITULOS
                 _detalhe.Append(Utils.FitStringLength(boleto.NumeroDocumento, 10, 10, '0', 0, true, true, true)); //Posição 111 a 120
                 _detalhe.Append(boleto.DataVencimento.ToString("ddMMyy")); //Posição 121 a 126
-                _detalhe.Append(Utils.FitStringLength(boleto.ValorBoleto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true)); //Posição 127 a 139 
+                _detalhe.Append(Utils.FitStringLength(boleto.ValorBoleto.ApenasNumeros(), 13, 13, '0', 0, true, true, true)); //Posição 127 a 139 
                 _detalhe.Append(boleto.Banco.Codigo); //Posição 140 a 142
                 _detalhe.Append(Utils.FitStringLength(boleto.Cedente.ContaBancaria.Agencia, 4, 4, '0', 0, true, true, true)); //Posição 143 a 146
                 _detalhe.Append(Utils.FitStringLength(boleto.Cedente.ContaBancaria.DigitoAgencia, 1, 1, '0', 0, true, true, true)); //Posição 147
@@ -460,9 +461,9 @@ namespace BoletoNet
                 _detalhe.Append(Utils.FitStringLength(Convert.ToInt32(boleto.PercMulta * 10000).ToString(), 6, 6, '0', 1, true, true, true)); //Posição 167 a 172
                 _detalhe.Append(" "); //Posição 173
                 _detalhe.Append(Utils.FitStringLength((boleto.DataDesconto == DateTime.MinValue ? "0" : boleto.DataDesconto.ToString("ddMMyy")), 6, 6, '0', 0, true, true, true)); //Posição 174 a 179
-                _detalhe.Append(Utils.FitStringLength(boleto.ValorDesconto.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true)); //Posição 180 a 192
-                _detalhe.Append("9" + Utils.FitStringLength(boleto.IOF.ToString("0.00").Replace(",", ""), 12, 12, '0', 0, true, true, true)); //Posição 193 a 205
-                _detalhe.Append(Utils.FitStringLength(boleto.Abatimento.ToString("0.00").Replace(",", ""), 13, 13, '0', 0, true, true, true)); //Posição 206 a 218
+                _detalhe.Append(Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 13, 13, '0', 0, true, true, true)); //Posição 180 a 192
+                _detalhe.Append("9" + Utils.FitStringLength(boleto.IOF.ApenasNumeros(), 12, 12, '0', 0, true, true, true)); //Posição 193 a 205
+                _detalhe.Append(Utils.FitStringLength(boleto.Abatimento.ApenasNumeros(), 13, 13, '0', 0, true, true, true)); //Posição 206 a 218
                 _detalhe.Append(Utils.IdentificaTipoInscricaoSacado(boleto.Sacado.CPFCNPJ)); //Posição 219 a 220
                 _detalhe.Append(Utils.FitStringLength(boleto.Sacado.CPFCNPJ.Replace(".", "").Replace("-", "").Replace("/", ""), 14, 14, '0', 0, true, true, true)); //Posição 221 a 234
                 _detalhe.Append(Utils.FitStringLength(boleto.Sacado.Nome, 40, 40, ' ', 0, true, true, false)); //Posição 235 a 274

--- a/src/Boleto.Net/Util/Extensions.cs
+++ b/src/Boleto.Net/Util/Extensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Collections;
 using System.Threading;
+using System.Globalization;
 
 namespace BoletoNet.Util
 {
@@ -42,6 +43,30 @@ namespace BoletoNet.Util
                     yield return resultSelector(e1.Current, e2.Current);
         }
 
+        /// <summary>
+        /// Retorna o valor atual removendo a vírgula
+        /// </summary>
+        /// <param name="valor"></param>
+        /// <returns></returns>
+        public static string ApenasNumeros(this decimal valor)
+        {
+            return valor.ToString("0.00", CultureInfo.GetCultureInfo("pt-BR")).Replace(",", "");
+        }
+
+        /// <summary>
+        /// Retorna o valor atual removendo a vírgula
+        /// </summary>
+        /// <param name="valor"></param>
+        /// <returns></returns>
+        public static string ApenasNumeros(this decimal? valor)
+        {
+            if (valor != null)
+            {
+                return valor.Value.ToString("0.00", CultureInfo.GetCultureInfo("pt-BR")).Replace(",", "");
+            }
+
+            return string.Empty;
+        }
         
     }
 


### PR DESCRIPTION
Em sistemas operacionais em inglês (como está o meu), isso pode falhar tentar remover a virgula da forma como estava antes e imprimir um ponto ao invés disso.
Como em alguns servidores não há permissão para se alterar a cultura da _thread_, achei melhor criar um método de extensão para fazer o tratamento.

Aqui está um exemplo para efeitos de comparação:
https://dotnetfiddle.net/RroVux
