### PR TITLE
CNAB400 Itaú deixar nome do sacador avalista em branco

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -1187,7 +1187,7 @@ namespace BoletoNet
                 // a) 2o e 3o descontos: para de operar com mais de um desconto(depende de cadastramento prévio do 
                 // indicador 19.0 pelo Banco Itaú, conforme item 5)
                 // b) Mensagens ao sacado: se utilizados as instruções 93 ou 94 (Nota 11), transcrever a mensagem desejada
-                _detalhe += Utils.FitStringLength(boleto.Sacado.Nome, 30, 30, ' ', 0, true, true, false).ToUpper();
+                _detalhe += new string(' ', 30);
                 _detalhe += "    "; // Complemento do registro
                 _detalhe += boleto.DataVencimento.ToString("ddMMyy");
                 // PRAZO - Quantidade de DIAS - ver nota 11(A) - depende das instruções de cobrança 


### PR DESCRIPTION
Deixar o nome do sacador avalista em branco na geração do arquivo de remessa CNAB400 do banco Itaú conforme. Vide #290.