### PR TITLE
Multa opcional no banco Itau

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
@@ -77,6 +77,18 @@ namespace BoletoNet
                             numeroRegistro++;
                         }
                     }
+
+                    // 341 - Banco Itau
+                    if (banco.Codigo == 341)
+                    {
+                        if (boleto.PercMulta > 0 || boleto.ValorMulta > 0)
+                        {
+                            Banco_Itau _banco = new Banco_Itau();
+                            strline = _banco.GerarRegistroDetalhe5(boleto, numeroRegistro);
+                            incluiLinha.WriteLine(strline);
+                            numeroRegistro++;
+                        }
+                    }
                     if ((boleto.Instrucoes != null && boleto.Instrucoes.Count > 0) || (boleto.Sacado.Instrucoes != null && boleto.Sacado.Instrucoes.Count > 0))
                     {
                         strline = boleto.Banco.GerarMensagemVariavelRemessa(boleto, ref numeroRegistro, TipoArquivo.CNAB400);

--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -1224,6 +1224,19 @@ namespace BoletoNet
             }
         }
 
+        public string GerarRegistroDetalhe5(Boleto boleto, int numeroRegistro)
+        {
+            StringBuilder detalhe = new StringBuilder();
+            detalhe.Append("2");                                        // 001
+            detalhe.Append("2");                                        // 002 VALOR EM PERCENTUAL
+            detalhe.Append(boleto.DataMulta.ToString("ddMMyyyy"));      // 003-010
+            detalhe.Append(Utils.FitStringLength(Convert.ToInt32(boleto.PercMulta * 100).ToString(), 13, 13, '0', 0, true, true, true)); // 011-023
+            detalhe.Append(new string(' ', 371));                       // 024 a 394
+            detalhe.Append(Utils.FitStringLength(numeroRegistro.ToString(), 6, 6, '0', 0, true, true, true)); // 395 a 400
+            //Retorno
+            return Utils.SubstituiCaracteresEspeciais(detalhe.ToString());
+        }
+
         # endregion DETALHE
 
         # region TRAILER CNAB240


### PR DESCRIPTION
4790 - Gerar o seguimento de detalhe opcional de multa do banco Ítau,
400 posições, quando for informado o percentual de multa do título.
Revision 18309.