### PR TITLE
Atualizações do banco do Sicred para homologação da remessa e retorno com o banco

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Sicredi.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicredi.cs
@@ -756,7 +756,7 @@ namespace BoletoNet
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0019, 001, 0, "A", ' '));                                       //019-019  Tipo de juros: 'A' - VALOR
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 028, 0, string.Empty, ' '));                              //020-047
                 #region Nosso Número + DV
-
+                boleto.DigitoNossoNumero = DigNossoNumeroSicredi(boleto);
                 string vAuxNossoNumeroComDV = boleto.NossoNumero.Replace("/", "").Replace("-", "");
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0048, 009, 0, vAuxNossoNumeroComDV, '0'));                      //048-056
                 #endregion
@@ -772,7 +772,7 @@ namespace BoletoNet
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0083, 010, 2, boleto.ValorDesconto, '0'));                      //083-092
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 004, 2, boleto.PercMulta, '0'));                          //093-096
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0097, 012, 0, string.Empty, ' '));                              //097-108
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "01", ' '));                                      //109-110 01 - Cadastro de título;
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, boleto.Remessa.CodigoOcorrencia, ' '));           //109-110 01 - Cadastro de título;
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NumeroDocumento, ' '));                    //111-120
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0121, 006, 0, boleto.DataVencimento, ' '));                     //121-126
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 013, 2, boleto.ValorBoleto, '0'));                        //127-139
@@ -783,7 +783,7 @@ namespace BoletoNet
                 #region Instruções
                 string vInstrucao1 = "00"; //1ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
                 string vInstrucao2 = "00"; //2ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
-                foreach (var instrucao in boleto.Instrucoes)
+                foreach (Instrucao instrucao in boleto.Instrucoes)
                 {
                     switch ((EnumInstrucoes_Sicredi)instrucao.Codigo)
                     {

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicredi.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicredi.cs
@@ -4,26 +4,26 @@ using System.Text;
 
 namespace BoletoNet
 {
+    #region Enumerado
+
+    public enum EnumEspecieDocumento_Sicredi
+    {
+        DuplicataMercantilIndicacao,
+        DuplicataRural,
+        NotaPromissoria,
+        NotaPromissoriaRural,
+        NotaSeguros,
+        Recibo,
+        LetraCambio,
+        NotaDebito,
+        DuplicataServicoIndicacao,
+        Outros,
+    }
+
+    #endregion 
+    
     public class EspecieDocumento_Sicredi : AbstractEspecieDocumento, IEspecieDocumento
     {
-        #region Enumerado
-
-        public enum EnumEspecieDocumento_Sicredi
-        {
-            DuplicataMercantilIndicacao,
-            DuplicataRural,
-            NotaPromissoria,
-            NotaPromissoriaRural,
-            NotaSeguros,
-            Recibo,
-            LetraCambio,
-            NotaDebito,
-            DuplicataServicoIndicacao,
-            Outros,
-        }
-
-        #endregion 
-
         #region Construtores
 
         public EspecieDocumento_Sicredi()
@@ -51,7 +51,7 @@ namespace BoletoNet
 
         #endregion
 
-         public static string getCodigoEspecieByEnum(EnumEspecieDocumento_Sicredi especie)
+         public string getCodigoEspecieByEnum(EnumEspecieDocumento_Sicredi especie)
         {
             switch (especie)
             {
@@ -163,9 +163,10 @@ namespace BoletoNet
         public static EspeciesDocumento CarregaTodas()
         {
             EspeciesDocumento especiesDocumento = new EspeciesDocumento();
+            EspecieDocumento_Sicredi ed = new EspecieDocumento_Sicredi();
 
             foreach (EnumEspecieDocumento_Sicredi item in Enum.GetValues(typeof(EnumEspecieDocumento_Sicredi)))
-                especiesDocumento.Add(new EspecieDocumento_Sicredi(getCodigoEspecieByEnum(item)));
+                especiesDocumento.Add(new EspecieDocumento_Sicredi(ed.getCodigoEspecieByEnum(item)));
 
             return especiesDocumento;
         }


### PR DESCRIPTION
Atualizações do banco do Sicred para homologação da remessa e retorno
com o banco

Padronizando código do banco Sicred para ficar conforme o padrão dos
outros bancos. Revision 17506.
Formatação do dígito do nosso número para gerar detalhe da remessa
CNAB400. Revision 17512, 17513 e 17514.
Configuração do código da ocorrência para gerar detalhe da remessa
CNAB400. Revision 17517.