### PR TITLE
Multa para CNAB240 CAIXA SIGCB e correção da substituição de Caracteres Especiais

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
@@ -123,7 +123,7 @@ namespace BoletoNet
                             numeroRegistro++;
                             numeroRegistroDetalhe++;
 
-                            if (boleto.PercMulta > 0 || boleto.PercMulta > 0)
+                            if (boleto.ValorMulta > 0 || boleto.PercMulta > 0)
                             {
                                 strline = boleto.Banco.GerarDetalheSegmentoRRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
                                 incluiLinha.WriteLine(strline);

--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
@@ -122,15 +122,15 @@ namespace BoletoNet
                             OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoQ);
                             numeroRegistro++;
                             numeroRegistroDetalhe++;
-                            //segmento R não implementado...
-                            //if (boleto.ValorMulta > 0)
-                            //{
-                            //    strline = boleto.Banco.GerarDetalheSegmentoRRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
-                            //    incluiLinha.WriteLine(strline);
-                            //    OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoR);
-                            //    numeroRegistro++;
-                            //    numeroRegistroDetalhe++;
-                            //}
+
+                            if (boleto.PercMulta > 0 || boleto.PercMulta > 0)
+                            {
+                                strline = boleto.Banco.GerarDetalheSegmentoRRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
+                                incluiLinha.WriteLine(strline);
+                                OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoR);
+                                numeroRegistro++;
+                                numeroRegistroDetalhe++;
+                            }
                         }
 
                         numeroRegistro--;

--- a/src/Boleto.Net/Util/Utils.cs
+++ b/src/Boleto.Net/Util/Utils.cs
@@ -439,7 +439,7 @@ namespace BoletoNet
                     if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
                         sb.Append(c);
                 }
-                return Regex.Replace(sb.ToString(), "[^0-9a-zA-Z°ºª&¹²³ ]+", "")
+                return Regex.Replace(sb.ToString(), @"[^0-9a-zA-Z°ºª&¹²³.,\\@\- ]+", " ")
                     .Replace("ª", "a")
                     .Replace("º", "o")
                     .Replace("°", "o")


### PR DESCRIPTION
Adicionado Segmento R do CNAB240 SIGCB da CAIXA com o valor da multa por valor fixo ou porcentagem.
Adicionado a troca de caracter especial para espaço e não somente remover o caracter, o que causava diminuição da linha das remessas e troca de posição de campos. Adicionado os caracteres válidos nos arquivos . , \ @ -