### PR TITLE
Fix bug - Retorno cnab400 Banco do Nordeste - Valores sem casa decimais

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Nordeste.cs
+++ b/src/Boleto.Net/Banco/Banco_Nordeste.cs
@@ -611,7 +611,7 @@ namespace BoletoNet
                 int dataVencimento = Utils.ToInt32(reg.DataVencimento);
                 detalhe.DataVencimento = Utils.ToDateTime(dataVencimento.ToString("##-##-##"));
                 //
-                detalhe.ValorTitulo = (Convert.ToInt64(reg.ValorTitulo) / 100);
+                detalhe.ValorTitulo = (Convert.ToDecimal(reg.ValorTitulo) / 100);
                 detalhe.CodigoBanco = Utils.ToInt32(reg.CodigoBancoRecebedor);
                 detalhe.AgenciaCobradora = Utils.ToInt32(reg.PrefixoAgenciaRecebedora);
                 //detalhe. = reg.DVPrefixoRecebedora;
@@ -620,17 +620,17 @@ namespace BoletoNet
                 int dataOcorrencia = Utils.ToInt32(reg.DataOcorrencia);
                 detalhe.DataOcorrencia = Utils.ToDateTime(dataOcorrencia.ToString("##-##-##"));
                 //
-                detalhe.TarifaCobranca = (Convert.ToInt64(reg.ValorTarifa) / 100);
-                detalhe.OutrasDespesas = (Convert.ToInt64(reg.OutrasDespesas) / 100);
-                detalhe.ValorOutrasDespesas = (Convert.ToInt64(reg.JurosDesconto) / 100);
+                detalhe.TarifaCobranca = (Convert.ToDecimal(reg.ValorTarifa) / 100);
+                detalhe.OutrasDespesas = (Convert.ToDecimal(reg.OutrasDespesas) / 100);
+                detalhe.ValorOutrasDespesas = (Convert.ToDecimal(reg.JurosDesconto) / 100);
                 //detalhe.IOF = (Convert.ToInt64(reg.IOFDesconto) / 100);
-                detalhe.Abatimentos = (Convert.ToInt64(reg.ValorAbatimento) / 100);
-                detalhe.Descontos = (Convert.ToInt64(reg.DescontoConcedido) / 100);
+                detalhe.Abatimentos = (Convert.ToDecimal(reg.ValorAbatimento) / 100);
+                detalhe.Descontos = (Convert.ToDecimal(reg.DescontoConcedido) / 100);
                 detalhe.ValorPrincipal = (Convert.ToInt64(reg.ValorRecebido) / 100);
-                detalhe.JurosMora = (Convert.ToInt64(reg.JurosMora) / 100);
+                detalhe.JurosMora = (Convert.ToDecimal(reg.JurosMora) / 100);
                 //detalhe.OutrosCreditos = (Convert.ToInt64(reg.OutrosRecebimentos) / 100);
                 //detalhe. = reg.AbatimentoNaoAproveitado;
-                detalhe.ValorPago = (Convert.ToInt64(reg.ValorRecebido) / 100);                
+                detalhe.ValorPago = (Convert.ToDecimal(reg.ValorRecebido) / 100);                
                 //detalhe. = reg.IndicativoDebitoCredito;
                 //detalhe. = reg.IndicadorValor;
                 //detalhe. = reg.ValorAjuste;


### PR DESCRIPTION
Estava convertendo valores decimais usando ```Convert.ToInt64```, foi alterado para ```Convert.ToDecimal```