### PR TITLE
Ajuste para evitar NullReferenceException em objeto Sigla

### DIFF
--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento.cs
@@ -61,7 +61,16 @@ namespace BoletoNet
 
         public override string Sigla
         {
-            get { return _IEspecieDocumento.Sigla; }
+            get
+            {
+
+                if (_IEspecieDocumento == null)
+                {
+                    return string.Empty;
+                }
+
+                return _IEspecieDocumento.Sigla;
+            }
             set { _IEspecieDocumento.Sigla = value; }
         }
 


### PR DESCRIPTION
Ajuste realizado para não ocorrer NullReferenceException nas chamadas realizadas no método ValidaSigla().
Embora haja o tratamento da exceção no método, é uma boa prática evitar a ocorrência de Exceptions sempre que possível. 