### PR TITLE
Correção do HTML que estava sem o campo @USODOBANCO

### DIFF
--- a/src/Boleto.Net/Html.Designer.cs
+++ b/src/Boleto.Net/Html.Designer.cs
@@ -506,12 +506,12 @@ namespace BoletoNet {
         ///						&lt;td class=&quot;w180&quot;&gt;(=) Valor documento&lt;/td&gt;
         ///				&lt;/tr&gt;
         ///				&lt;tr class=&quot;cp h12 rBb&quot;&gt;
-        ///						&lt;td&gt;&amp;nbsp;&lt;/td&gt;
+        ///						&lt;td&gt;@USODOBANCO&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@CARTEIRA&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@ESPECIE&lt;/td&gt;
         ///						&lt;td&gt;@QUANTIDADE&lt;/td&gt;
         ///						&lt;td&gt;@VALORDOCUMENTO&lt;/td&gt;
-        ///						&lt;td class=&quot;Ar&quot;&gt;@=VALO [rest of string was truncated]&quot;;.
+        ///						&lt;td class=&quot;Ar&quot;&gt;@ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte5 {
             get {

--- a/src/Boleto.Net/Html.resx
+++ b/src/Boleto.Net/Html.resx
@@ -430,7 +430,7 @@
 						&lt;td class="w180"&gt;(=) Valor documento&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
-						&lt;td&gt;&amp;nbsp;&lt;/td&gt;
+						&lt;td&gt;@USODOBANCO&lt;/td&gt;
 						&lt;td class="Al"&gt;@CARTEIRA&lt;/td&gt;
 						&lt;td class="Al"&gt;@ESPECIE&lt;/td&gt;
 						&lt;td&gt;@QUANTIDADE&lt;/td&gt;


### PR DESCRIPTION
Ao imprimir os boletos, o campo Boleto.UsoBanco não estava sendo exibido, pois no HTML estava faltando a utilização da variável @USODOBANCO. Corrigi o Html.resx para que tal variável seja exibida adequadamente na impressão do HTML ou PDF.