### PR TITLE
Correções de erro pedido de baixa Santander

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
@@ -187,26 +187,30 @@ namespace BoletoNet
                         numeroRegistro++;
                         numeroRegistroDetalhe++;
 
-                        strline = boleto.Banco.GerarDetalheSegmentoQRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
-                        incluiLinha.WriteLine(strline);
-                        OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoQ);
-                        numeroRegistro++;
-                        numeroRegistroDetalhe++;
-
-                        if (boleto.ValorMulta > 0 || boleto.OutrosDescontos > 0 || boleto.PercMulta > 0)
+                        if (boletos[0].Remessa.CodigoOcorrencia == "01")
                         {
-                            strline = boleto.Banco.GerarDetalheSegmentoRRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
+
+                            strline = boleto.Banco.GerarDetalheSegmentoQRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
                             incluiLinha.WriteLine(strline);
-                            OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoR);
+                            OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoQ);
+                            numeroRegistro++;
+                            numeroRegistroDetalhe++;
+
+                            if (boleto.ValorMulta > 0 || boleto.OutrosDescontos > 0 || boleto.PercMulta > 0)
+                            {
+                                strline = boleto.Banco.GerarDetalheSegmentoRRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
+                                incluiLinha.WriteLine(strline);
+                                OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoR);
+                                numeroRegistro++;
+                                numeroRegistroDetalhe++;
+                            }
+
+                            strline = boleto.Banco.GerarDetalheSegmentoSRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
+                            incluiLinha.WriteLine(strline);
+                            OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoS);
                             numeroRegistro++;
                             numeroRegistroDetalhe++;
                         }
-
-                        strline = boleto.Banco.GerarDetalheSegmentoSRemessa(boleto, numeroRegistroDetalhe, TipoArquivo.CNAB240);
-                        incluiLinha.WriteLine(strline);
-                        OnLinhaGerada(boleto, strline, EnumTipodeLinha.DetalheSegmentoS);
-                        numeroRegistro++;
-                        numeroRegistroDetalhe++;
                     }
 
                     strline = banco.GerarTrailerLoteRemessa(numeroRegistro);


### PR DESCRIPTION
Em homologação co mo banco Santander, foi solicitado não mandar os
seguimentos Q, R e S para pedido de baixa.
Revision 19323/Chamado 202374 - No arquivo da remessa do pedido de baixa
do banco Santander (033), não mandar os seguimentos Q, R (opcional) e S
(opcional), segundo o manual técnico e a orientação do banco.