### PR TITLE
Alteração de valor fixo do identificador de título aceito no arquivo de remessa Cnab400 Itaú

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -1190,7 +1190,7 @@ namespace BoletoNet
                 _detalhe += "00000"; // Agência onde o título será cobrado - no arquivo de remessa, preencher com ZEROS
 
                 _detalhe += Utils.FitStringLength(EspecieDocumento.ValidaCodigo(boleto.EspecieDocumento).ToString(), 2, 2, '0', 0, true, true, true);
-                _detalhe += "A"; // Identificação de título, Aceito ou Não aceito
+                _detalhe += Utils.FitStringLength(boleto.Aceite, 1, 1, ' ', 0, true, true, false); // Identificação de título, Aceito ou Não aceito
 
                 //A data informada neste campo deve ser a mesma data de emissão do título de crédito 
                 //(Duplicata de Serviço / Duplicata Mercantil / Nota Fiscal, etc), que deu origem a esta Cobrança. 


### PR DESCRIPTION
Alteração no método GerarDetalheRemessaCNAB400 da classe Banco_Itau, pois o valor da identificação do título aceito ou não aceito está com o valor fixo "A".