### PR TITLE
BB Remessa 240 - Padronizado contagem de registro 240

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB240.cs
@@ -287,7 +287,7 @@ namespace BoletoNet
                     }
 
 
-                    numeroRegistro--;
+                    //numeroRegistro--;
                     strline = banco.GerarTrailerLoteRemessa(numeroRegistro);
                     incluiLinha.WriteLine(strline);
                     OnLinhaGerada(null, strline, EnumTipodeLinha.TraillerDeLote);

--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -1748,16 +1748,7 @@ namespace BoletoNet
                 trailer += Utils.FitStringLength("1", 4, 4, '0', 0, true, true, true);
                 trailer += "5";
                 trailer += Utils.FormatCode("", " ", 9);
-
-                #region Pega o Numero de Registros + 1(HeaderLote) + 1(TrailerLote)
-                // Alterado por Heric Souza em 02/06/2017
-                int vQtdeRegLote = (numeroRegistro + 1); // (numeroRegistro + 2);
-                //int vQtdeRegLote = numeroRegistro; // (numeroRegistro + 2);
-                trailer += Utils.FitStringLength(vQtdeRegLote.ToString(), 6, 6, '0', 0, true, true, true);  //posição 18 até 23   (6) - Quantidade de Registros no Lote
-                //deve considerar 1 registro a mais - Header
-                #endregion
-
-
+                trailer += Utils.FitStringLength(numeroRegistro.ToString(), 6, 6, '0', 0, true, true, true);  //posição 18 até 23   (6) - Quantidade de Registros no Lote
                 trailer += Utils.FormatCode("", "0", 92, true);
                 trailer += Utils.FormatCode("", " ", 125);
                 trailer = Utils.SubstituiCaracteresEspeciais(trailer);
@@ -1778,7 +1769,7 @@ namespace BoletoNet
                 string _trailerArquivo;
 
                 _trailerArquivo = "00199999         000001";
-                _trailerArquivo += Utils.FitStringLength((numeroRegistro + 1).ToString(), 6, 6, '0', 0, true, true, true); //deve considerar 1 registro a mais - Header
+                _trailerArquivo += Utils.FitStringLength((numeroRegistro).ToString(), 6, 6, '0', 0, true, true, true);
                 _trailerArquivo += "000000";
                 _trailerArquivo += _brancos205;
 

--- a/src/Boleto.Net/Banco/Banco_Cecred.cs
+++ b/src/Boleto.Net/Banco/Banco_Cecred.cs
@@ -721,11 +721,9 @@ namespace BoletoNet {
 
                 _trailer += Utils.FormatCode("", " ", 9);                               // Uso Exclusivo FEBRABAN/CNAB
 
-                var _numReg = numeroRegistro + 1;
-
                 // Totais
                 _trailer += "000001";                                                   // 018-023 Quantidade de Lotes do Arquivo
-                _trailer += Utils.FormatCode(_numReg.ToString(), "0", 6, true);  // 024-029 Quantidade de Registros do Arquivo
+                _trailer += Utils.FormatCode(numeroRegistro.ToString(), "0", 6, true);  // 024-029 Quantidade de Registros do Arquivo
                 _trailer += "000000";                                                   // 030-035 Qtde de Contas p/ Conc. (Lotes)
                 _trailer += Utils.FormatCode("", " ", 205);                             // 036-240 Uso Exclusivo FEBRABAN/CNAB
 


### PR DESCRIPTION
Conforme outros bancos e histórico de alterações

1- Aqui mudou para somar +1 @LeandroCDS  https://github.com/BoletoNet/boletonet/commit/47d0e5fe10e36b65e0340d6b3c3880032d8c6ad3

2- Aqui remover a soma +1 e deixou comentado uma region com informações de somas @ecfenix1  https://github.com/BoletoNet/boletonet/commit/6acb02ccc921a7490be87af200ec5b0392b7d712

3- Aqui voltamos a somar +1 @hericss https://github.com/BoletoNet/boletonet/commit/7ce9d3f38a3e73d088b89e3c2ee4437a4288f74d

Obs: outros bancos não existe essa soma +1 no método GerarTrailerLoteRemessa, quem controla essa soma é o ArquivoRemessaCNAB240.cs linha 290