### PR TITLE
Adicionar na lista de enum do BB, [DAE, DAM, DAU]

### DIFF
--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BancoBrasil.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BancoBrasil.cs
@@ -30,7 +30,10 @@ namespace BoletoNet
         ApoliceSeguro = 20, //AP –  APÓLICE DE SEGURO
         MensalidadeEscolar = 21, //ME – MENSALIDADE ESCOLAR
         ParcelaConsorcio = 22, //PC –  PARCELA DE CONSÓRCIO
-        Outros = 23 //OUTROS
+        Outros = 23, //OUTROS                
+        DividaAtivaEstadual = 27, //DAE - DÍVIDA ATIVA DO ESTADO
+        DividaAtivaMunicipio = 28, //DAM - DÍVIDA ATIVA DO MUNICIPIO
+        DividaAtivaUniao = 29 //DAU - DÍVIDA ATIVA DA UNIÃO
     }
 
     #endregion
@@ -93,8 +96,10 @@ namespace BoletoNet
                 case EnumEspecieDocumento_BancoBrasil.MensalidadeEscolar: return "21";
                 case EnumEspecieDocumento_BancoBrasil.ParcelaConsorcio: return "22";
                 case EnumEspecieDocumento_BancoBrasil.Outros: return "23";
+                case EnumEspecieDocumento_BancoBrasil.DividaAtivaEstadual: return "27";
+                case EnumEspecieDocumento_BancoBrasil.DividaAtivaMunicipio: return "28";
+                case EnumEspecieDocumento_BancoBrasil.DividaAtivaUniao: return "29";
                 default: return "23";
-
             }
         }
 
@@ -125,6 +130,9 @@ namespace BoletoNet
                 case "21": return EnumEspecieDocumento_BancoBrasil.MensalidadeEscolar;
                 case "22": return EnumEspecieDocumento_BancoBrasil.ParcelaConsorcio;
                 case "23": return EnumEspecieDocumento_BancoBrasil.Outros;
+                case "27": return EnumEspecieDocumento_BancoBrasil.DividaAtivaEstadual;
+                case "28": return EnumEspecieDocumento_BancoBrasil.DividaAtivaMunicipio;
+                case "29": return EnumEspecieDocumento_BancoBrasil.DividaAtivaUniao;
                 default: return EnumEspecieDocumento_BancoBrasil.DuplicataMercantil;
             }
         }
@@ -252,6 +260,21 @@ namespace BoletoNet
                         this.Especie = "OUTROS";
                         this.Sigla = "OUTROS";
                         break;
+                    case EnumEspecieDocumento_BancoBrasil.DividaAtivaEstadual:
+                        this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaEstadual);
+                        this.Especie = "DÍVIDA ATIVA DO ESTADO";
+                        this.Sigla = "DAE";
+                        break;
+                    case EnumEspecieDocumento_BancoBrasil.DividaAtivaMunicipio:
+                        this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaMunicipio);
+                        this.Especie = "DÍVIDA ATIVA DO MUNICIPIO";
+                        this.Sigla = "DAM";
+                        break;
+                    case EnumEspecieDocumento_BancoBrasil.DividaAtivaUniao:
+                        this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaUniao);
+                        this.Especie = "DÍVIDA ATIVA DA UNIÃO";
+                        this.Sigla = "DAU";
+                        break;
                     default:
                         this.Codigo = "0";
                         this.Especie = "( Selecione )";
@@ -294,6 +317,9 @@ namespace BoletoNet
                 alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.MensalidadeEscolar)));
                 alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.ParcelaConsorcio)));
                 alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.Outros)));
+                alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaEstadual)));
+                alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaMunicipio)));
+                alEspeciesDocumento.Add(new EspecieDocumento_BancoBrasil(ed.getCodigoEspecieByEnum(EnumEspecieDocumento_BancoBrasil.DividaAtivaUniao)));
 
                 return alEspeciesDocumento;
             }
@@ -311,3 +337,4 @@ namespace BoletoNet
         #endregion
     }
 }
+


### PR DESCRIPTION
Nos boletos emitidos para o Banco do Brasil
Preciso informar uma especie de documento de divida ativa do estado [DAE]
Para atender uma necessidade existente no órgão do estado em que eu trabalho

O problema existia porque na lista de enumeradores não havia os de Divida Ativa do Estado, Município e União.