### PR TITLE
Erro na conversão da Data de inicio para Cobrança da Multa

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -2304,11 +2304,11 @@ namespace BoletoNet
                     #region DataVencimento
                     string vDataVencimento = "000000";
                     if (!boleto.DataVencimento.Equals(DateTime.MinValue))
-                        vDataVencimento = boleto.DataVencimento.ToString("ddMMyy");
+                        vDataVencimento = boleto.DataVencimento.ToString("dd/MM/yy");
                     #endregion
 
                     reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0174, 001, 0, vCodigoMulta, '0'));                          //174 a 174      Código da Multa 1=Valor 
-                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0175, 006, 0, vDataVencimento, ' '));                       //175 a 180      Data de inicio para Cobrança da Multa 
+                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0175, 006, 0, DateTime.Parse(vDataVencimento), ' '));       //175 a 180      Data de inicio para Cobrança da Multa 
                     reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0180, 013, 2, vMulta, '0'));                                //181 a 192      Valor de Multa 
                 }
                 else

--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -2305,6 +2305,8 @@ namespace BoletoNet
                     string vDataVencimento = "000000";
                     if (!boleto.DataVencimento.Equals(DateTime.MinValue))
                         vDataVencimento = boleto.DataVencimento.ToString("dd/MM/yy");
+                    else
+                        throw new Exception("Data de inicio para Cobrança da Multa inválida.");
                     #endregion
 
                     reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0174, 001, 0, vCodigoMulta, '0'));                          //174 a 174      Código da Multa 1=Valor 


### PR DESCRIPTION
Corrige erro na conversão da Data de inicio para Cobrança da Multa no método GerarDetalheRemessaCNAB400 para o Banco do Brasil.