### PR TITLE
Correções da Impressão Carne e Remessa Banco Sicredi

### DIFF
--- a/src/.vs/config/applicationhost.config
+++ b/src/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Boleto.Net.Site" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="D:\fontes\GitHub\BoletoNet_fork\src\Boleto.Net.Site" />
+                    <virtualDirectory path="/" physicalPath="D:\Documents\Visual Studio 2015\Projects\Boleto.net\boletonet\src\Boleto.Net.Site" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:3304:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="Boleto.Net.MVC" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="D:\fontes\GitHub\BoletoNet_fork\src\Boleto.Net.MVC" />
+                    <virtualDirectory path="/" physicalPath="D:\Documents\Visual Studio 2015\Projects\Boleto.net\boletonet\src\Boleto.Net.MVC" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:26014:localhost" />

--- a/src/Boleto.Net.Arquivo/Main.Designer.cs
+++ b/src/Boleto.Net.Arquivo/Main.Designer.cs
@@ -267,7 +267,7 @@ namespace BoletoNet.Arquivo
             this.radioButtonSicredi.Name = "radioButtonSicredi";
             this.radioButtonSicredi.Size = new System.Drawing.Size(57, 17);
             this.radioButtonSicredi.TabIndex = 29;
-            this.radioButtonSicredi.Tag = "104";
+            this.radioButtonSicredi.Tag = "748";
             this.radioButtonSicredi.Text = "Sicredi";
             this.radioButtonSicredi.UseVisualStyleBackColor = true;
             // 

--- a/src/Boleto.Net.Arquivo/Main.cs
+++ b/src/Boleto.Net.Arquivo/Main.cs
@@ -594,6 +594,8 @@ namespace BoletoNet.Arquivo
                 form.CodigoBanco = Convert.ToInt16(radioButtonCaixa.Tag);
             else if (radioButtonBNB.Checked)
                 form.CodigoBanco = Convert.ToInt16(radioButtonBNB.Tag);
+            else if (radioButtonSicredi.Checked)
+                form.CodigoBanco = Convert.ToInt16(radioButtonSicredi.Tag);
 
 
             form.ShowDialog();

--- a/src/Boleto.Net.Arquivo/NBoleto.cs
+++ b/src/Boleto.Net.Arquivo/NBoleto.cs
@@ -121,6 +121,69 @@ namespace BoletoNet.Arquivo
         }
         #endregion
 
+        #region BOLETO Caixa
+        private void GeraBoletoSicredi(int qtde)
+        {
+            // Cria o boleto, e passa os parâmetros usuais
+            BoletoBancario bb;
+
+            List<BoletoBancario> boletos = new List<BoletoBancario>();
+            for (int i = 0; i < qtde; i++)
+            {
+
+                bb = new BoletoBancario();
+                bb.CodigoBanco = _codigoBanco;
+                bb.MostrarEnderecoCedente = true;                
+                bb.FormatoCarne = true;
+                bb.OcultarInstrucoes = true;
+                DateTime vencimento = DateTime.Now.AddDays(10);
+
+                Instrucao_Sicredi item1 = new Instrucao_Sicredi((int)EnumInstrucoes_Sicredi.AlteracaoOutrosDados_Desconto, (Double)50.90, AbstractInstrucao.EnumTipoValor.Reais);
+              
+             
+                Cedente c = new Cedente("00.000.000/0000-00", "Empresa de Atacado", "0132", "00542");
+                c.Codigo = "01321000542";
+                c.ContaBancaria.Agencia = "0132";               
+                c.ContaBancaria.Conta = "00542";
+                c.ContaBancaria.OperacaConta = "10";
+
+                Boleto b = new Boleto(vencimento, Convert.ToDecimal(1460), "1", "17200001" , c, new EspecieDocumento(_codigoBanco, "A"));
+               
+                Endereco endCed = new Endereco();
+
+                b.NumeroParcela = 1;
+                b.TotalParcela = 10;
+                b.TipoImpressao = "B";
+
+
+                endCed.End = "Rua Testando o Boleto";
+                endCed.Bairro = "BairroTest";
+                endCed.Cidade = "CidadeTes";
+                endCed.CEP = "70000000";
+                endCed.UF = "MG";
+                b.Cedente.Endereco = endCed;
+
+                b.NumeroDocumento = "1001";
+
+                b.Sacado = new Sacado("000.000.000-00", "Fulano de Silva");
+                b.Sacado.Endereco.End = "SSS 154 Bloco J Casa 23";
+                b.Sacado.Endereco.Bairro = "Testando";
+                b.Sacado.Endereco.Cidade = "Testelândia";
+                b.Sacado.Endereco.CEP = "70000000";
+                b.Sacado.Endereco.UF = "DF";
+                b.Instrucoes.Add(item1);
+              
+
+                bb.Boleto = b;
+                bb.Boleto.Valida();
+
+                boletos.Add(bb);
+            }
+
+            GeraLayout(boletos);
+        }
+        #endregion
+
         #region BOLETO ITAÚ
         private void GeraBoletoItau(int qtde)
         {
@@ -175,7 +238,6 @@ namespace BoletoNet.Arquivo
         }
         #endregion
 
-
         #region BOLETO UNIBANCO
         public void GeraBoletoUnibanco(int qtde)
         {
@@ -220,8 +282,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO SUDAMERIS
         public void GeraBoletoSudameris(int qtde)
         {
@@ -269,8 +330,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO SAFRA
         public void GeraBoletoSafra(int qtde)
         {
@@ -312,8 +372,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO REAL
         public void GeraBoletoReal(int qtde)
         {
@@ -355,8 +414,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO HSBC
         public void GeraBoletoHsbc(int qtde)
         {
@@ -399,8 +457,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO BANCO DO BRASIL
         public void GeraBoletoBB(int qtde)
         {
@@ -450,8 +507,7 @@ namespace BoletoNet.Arquivo
             GeraLayout(boletos);
         }
         #endregion
-
-
+        
         #region BOLETO BRADESCO
         public void GeraBoletoBradesco(int qtde)
         {
@@ -598,6 +654,10 @@ namespace BoletoNet.Arquivo
                     break;
                 case 4: //BNB
                     GeraBoletoBNB((int)numericUpDown.Value);
+                    break;
+
+                case 748:
+                    GeraBoletoSicredi((int)numericUpDown.Value);
                     break;
             }
 

--- a/src/Boleto.Net/Banco/Banco_Sicredi.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicredi.cs
@@ -721,7 +721,7 @@ namespace BoletoNet
                              !boleto.EspecieDocumento.Codigo.Equals("D") && //D - Nota Promissória Rural;
                              !boleto.EspecieDocumento.Codigo.Equals("E") && //E - Nota de Seguros;
                              !boleto.EspecieDocumento.Codigo.Equals("F") && //G – Recibo;
-                             
+
                              !boleto.EspecieDocumento.Codigo.Equals("H") && //H - Letra de Câmbio;
                              !boleto.EspecieDocumento.Codigo.Equals("I") && //I - Nota de Débito;
                              !boleto.EspecieDocumento.Codigo.Equals("J") && //J - Duplicata de Serviço por Indicação;
@@ -742,7 +742,12 @@ namespace BoletoNet
                         //sidnei.klein: Segundo definição recebida pelo Sicredi-RS, o Nosso Número sempre terá somente 8 caracteres sem o DV que está no boleto.DigitoNossoNumero
                         vMsg += String.Concat("Boleto: ", boleto.NumeroDocumento, "; Remessa: O Nosso Número diferente de 8 caracteres!", Environment.NewLine);
                         vRetorno = false;
-                    }            
+                    }
+                    else if (!boleto.TipoImpressao.Equals("A") || !boleto.TipoImpressao.Equals("B"))
+                    {
+                        vMsg += String.Concat("Boleto: ", boleto.NumeroDocumento, "; Tipo de Impressão deve conter A - Normal ou B - Carnê", Environment.NewLine);
+                        vRetorno = false;
+                    }
                     #endregion
                 }
                 #endregion
@@ -799,7 +804,7 @@ namespace BoletoNet
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0001, 001, 0, "1", ' '));                                       //001-001
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 001, 0, "A", ' '));                                       //002-002  'A' - SICREDI com Registro
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0003, 001, 0, "A", ' '));                                       //003-003  'A' - Simples
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0004, 001, 0, "A", ' '));                                       //004-004  'A' – Normal
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0004, 001, 0, boleto.TipoImpressao, ' '));                                       //004-004  'A' – Normal
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0005, 012, 0, string.Empty, ' '));                              //005-016
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0017, 001, 0, "A", ' '));                                       //017-017  Tipo de moeda: 'A' - REAL
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0018, 001, 0, "A", ' '));                                       //018-018  Tipo de desconto: 'A' - VALOR
@@ -835,10 +840,18 @@ namespace BoletoNet
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0072, 001, 0, "N", ' '));                                       //072-072 'N' - Não Postar e remeter para o beneficiário
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 001, 0, string.Empty, ' '));                              //073-073
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 001, 0, "B", ' '));                                       //074-074 'B' – Impressão é feita pelo Beneficiário
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 002, 0, 0, '0'));                                         //075-076
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0077, 002, 0, 0, '0'));                                         //077-078
+                if (boleto.TipoImpressao.Equals("A"))
+                {
+                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 002, 0, 0, '0'));                                      //075-076
+                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0077, 002, 0, 0, '0'));                                      //077-078
+                }
+                else if (boleto.TipoImpressao.Equals("B"))
+                {
+                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0075, 002, 0, boleto.NumeroParcela, '0'));                   //075-076
+                    reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0077, 002, 0, boleto.TotalParcela, '0'));                    //077-078
+                }
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0079, 004, 0, string.Empty, ' '));                              //079-082
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0083, 010, 2, boleto.ValorDesconto, '0'));                      //083-092
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0083, 010, 2, boleto.ValorDescontoAntecipacao, '0'));           //083-092
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 004, 2, boleto.PercMulta, '0'));                          //093-096
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0097, 012, 0, string.Empty, ' '));                              //097-108
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, ObterCodigoDaOcorrencia(boleto), ' '));           //109-110 01 - Cadastro de título;

--- a/src/Boleto.Net/Boleto/Boleto.cs
+++ b/src/Boleto.Net/Boleto/Boleto.cs
@@ -23,6 +23,7 @@ namespace BoletoNet
 		private DateTime _dataVencimento;
 		private DateTime _dataDocumento;
 		private DateTime _dataProcessamento;
+        private int _totalParcela;
 		private int _numeroParcela;
 		private decimal _valorBoleto;
 		private decimal _valorCobrado;
@@ -44,6 +45,7 @@ namespace BoletoNet
 		private IBanco _banco;
 		private ContaBancaria _contaBancaria = new ContaBancaria();
 		private decimal _valorDesconto;
+        private decimal _valorDescontoAntecipacao;
 		private Sacado _sacado;
 		private bool _jurosPermanente;
 
@@ -67,6 +69,7 @@ namespace BoletoNet
 		private string _numeroControle;
 
 		private string _tipoModalidade = string.Empty;
+        private string _tipoImpressao = "A";
 		private Remessa _remessa;
 
 		private ObservableCollection<GrupoDemonstrativo> _demonstrativos;
@@ -290,6 +293,15 @@ namespace BoletoNet
 			set { this._numeroParcela = value; }
 		}
 
+        /// <summary> 
+		/// Retorna o total de parcelas
+		/// </summary>   
+        public int TotalParcela
+        {
+            get { return this._totalParcela; }
+            set { this._totalParcela = value; }
+        }
+
 		/// <summary> 
 		/// Recupara o número do documento
 		/// </summary>        
@@ -368,10 +380,20 @@ namespace BoletoNet
 			set { this._valorDesconto = value; }
 		}
 
-		/// <summary>
-		/// Retorna do Sacado
+        /// <summary> 
+		/// Retorna o valor do desconto por dia de antecipação do titulo.
+        /// Esse campo é utilizado no banco sicredi posição 083-092 registro detalhe remessa
 		/// </summary>
-		public Sacado Sacado
+		public decimal ValorDescontoAntecipacao
+        {
+            get { return this._valorDescontoAntecipacao; }
+            set { this._valorDescontoAntecipacao = value; }
+        }
+
+        /// <summary>
+        /// Retorna do Sacado
+        /// </summary>
+        public Sacado Sacado
 		{
 			get { return this._sacado; }
 			set { this._sacado = value; }
@@ -539,6 +561,14 @@ namespace BoletoNet
 			set { this._tipoModalidade = value; }
 		}
 
+        /// <summary> 
+		/// Tipo de Impressão Sicredi "A" = Boleto/ "B" = Carne
+		/// </summary>
+        public string TipoImpressao
+        {
+            get { return this._tipoImpressao; }
+            set { this._tipoImpressao = value; }
+        }
 		/// <summary> 
 		/// Retorna o percentual IOS para Seguradoras no caso do Banco Santander
 		/// </summary>

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -750,7 +750,9 @@ namespace BoletoNet
                         "{0} - {1}",
                         Boleto.Avalista != null ? Boleto.Avalista.Nome : string.Empty,
                         Boleto.Avalista != null ? Boleto.Avalista.CPFCNPJ : string.Empty))
-                .Replace("Ar\">R$", RemoveSimboloMoedaValorDocumento ? "Ar\">" : "Ar\">R$");
+                .Replace("Ar\">R$", RemoveSimboloMoedaValorDocumento ? "Ar\">" : "Ar\">R$")
+                .Replace("@PARCELATOTAL",Boleto.NumeroParcela != 0 && Boleto.TotalParcela != 0 ? Boleto.NumeroParcela + " / " + Boleto.TotalParcela : string.Empty);
+                
 
         }
 

--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -317,14 +317,13 @@ namespace BoletoNet
             }
         }
 
-        private string GeraHtmlCarne(string telefone, string htmlBoleto)
+        private string GeraHtmlCarne(string htmlBoleto)
         {
             var html = new StringBuilder();
 
             html.Append(Html.Carne);
 
-            return html.ToString()
-                .Replace("@TELEFONE", telefone)
+            return html.ToString()                
                 .Replace("#BOLETO#", htmlBoleto);
         }
         public string GeraHtmlReciboSacado()
@@ -666,7 +665,7 @@ namespace BoletoNet
                 html.Append(GeraHtmlReciboCedente());
             else
             {
-                html.Append(GeraHtmlCarne("", GeraHtmlReciboCedente()));
+                html.Append(GeraHtmlCarne(GeraHtmlReciboCedente()));
             }
 
             string dataVencimento = Boleto.DataVencimento.ToString("dd/MM/yyyy");

--- a/src/Boleto.Net/Html.Designer.cs
+++ b/src/Boleto.Net/Html.Designer.cs
@@ -111,10 +111,10 @@ namespace BoletoNet {
         ///   Looks up a localized string similar to &lt;table cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;&gt;
         ///						&lt;tr&gt;
         ///								&lt;td valign=&quot;top&quot;&gt;
-        ///										&lt;table class=&quot;w150 mt23&quot;&gt;
-        ///												&lt;tr class=&quot;ct cpN BHead&quot;&gt;
-        ///														&lt;td class=&quot;ld&quot;&gt;
-        ///																Recibo do Pagador
+        ///										&lt;table class=&quot;150&quot;&gt;
+        ///												&lt;tr class=&quot;BHead&quot;&gt;
+        ///														&lt;td class=&quot;imgLogo Al&quot;&gt;
+        ///															&lt;img src=&quot;@URLIMAGEMLOGO&quot; /&gt;
         ///														&lt;/td&gt;
         ///												&lt;/tr&gt;
         ///										&lt;/table&gt;
@@ -125,7 +125,7 @@ namespace BoletoNet {
         ///														&lt;/td&gt;
         ///												&lt;/tr&gt;
         ///												&lt;tr class=&quot;cp h12 At rBb&quot;&gt;
-        ///														&lt;td&gt;        /// [rest of string was truncated]&quot;;.
+        ///														 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Carne {
             get {

--- a/src/Boleto.Net/Html.resx
+++ b/src/Boleto.Net/Html.resx
@@ -615,10 +615,10 @@
     <value>&lt;table cellpadding="0" cellspacing="0"&gt;
 						&lt;tr&gt;
 								&lt;td valign="top"&gt;
-										&lt;table class="w150 mt23"&gt;
-												&lt;tr class="ct cpN BHead"&gt;
-														&lt;td class="ld"&gt;
-																Recibo do Pagador
+										&lt;table class="150"&gt;
+												&lt;tr class="BHead"&gt;
+														&lt;td class="imgLogo Al"&gt;
+															&lt;img src="@URLIMAGEMLOGO" /&gt;
 														&lt;/td&gt;
 												&lt;/tr&gt;
 										&lt;/table&gt;
@@ -633,26 +633,20 @@
 																@CEDENTE
 														&lt;/td&gt;
 												&lt;/tr&gt;
-										&lt;/table&gt;
-										&lt;table class="w150"&gt;
-												&lt;tr class="ct h13 At"&gt;
-														&lt;td class="w298"&gt;
-																Telefone
-														&lt;/td&gt;
-												&lt;/tr&gt;
-												&lt;tr class="cp h12 At rBb"&gt;
-														&lt;td&gt;
-																@TELEFONE
-														&lt;/td&gt;
-												&lt;/tr&gt;
-										&lt;/table&gt;
+										&lt;/table&gt;										
 										&lt;table class="w150"&gt;
 												&lt;tr class="ct h13"&gt;
+														&lt;td class="w192"&gt;
+																Parcela/Total
+														&lt;/td&gt;
 														&lt;td class="w192"&gt;
 																Vencimento
 														&lt;/td&gt;
 												&lt;/tr&gt;
 												&lt;tr class="cp h12 rBb"&gt;
+														&lt;td&gt;
+																@PARCELATOTAL
+														&lt;/td&gt;
 														&lt;td&gt;
 																@DATAVENCIMENTO
 														&lt;/td&gt;
@@ -672,18 +666,6 @@
 										&lt;/table&gt;
 										&lt;table class="w150"&gt;
 												&lt;tr class="ct h13"&gt;
-														&lt;td class="w192"&gt;
-																Número do documento
-														&lt;/td&gt;
-												&lt;/tr&gt;
-												&lt;tr class="cp h12 rBb"&gt;
-														&lt;td&gt;
-																@NUMERODOCUMENTO
-														&lt;/td&gt;
-												&lt;/tr&gt;
-										&lt;/table&gt;
-										&lt;table class="w150"&gt;
-												&lt;tr class="ct h13"&gt;
 														&lt;td class="w113"&gt;
 																(=) Valor do Documento
 														&lt;/td&gt;
@@ -691,6 +673,54 @@
 												&lt;tr class="cp h12 rBb Ab"&gt;
 														&lt;td&gt;
 																@=VALORDOCUMENTO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(-) Desconto / Abatimentos
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@DESCONTOS
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(-) Outras deduções
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@OUTRASDEDUCOES
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(+) Mora / Multa
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@MORAMULTA
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(+) Outros acréscimos
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@OUTROSACRESCIMOS
 														&lt;/td&gt;
 												&lt;/tr&gt;
 										&lt;/table&gt;
@@ -706,6 +736,30 @@
 														&lt;/td&gt;
 												&lt;/tr&gt;
 										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13 At"&gt;
+														&lt;td class="w298"&gt;
+																Nosso Número
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 At rBb"&gt;
+														&lt;td&gt;
+																@NOSSONUMERO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w192"&gt;
+																Número do documento
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb"&gt;
+														&lt;td&gt;
+																@NUMERODOCUMENTO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;										
 										&lt;table class="w150"&gt;
 												&lt;tr class="ct h13"&gt;
 														&lt;td class="w113"&gt;


### PR DESCRIPTION
Olá Boa tarde.

Fiz algumas alteração para possibilitar a impressão de boletos no formato carnê do banco sicredi.

 - O Campo de desconto estava aplicado em 2 lugares do arquivo de remessa, desconto por dia de antecipação e também no desconto até vencimento. Separei em 2 propriedades diferentes.

 - Não existia a opção de tipo de impressão a posição 004 do arquivo de remessa pede uma parâmetro "A" para normal e "B" para carnê estava fixado em "A".

 - Não existia o parâmetro total parcelas quando solicitada a impressão em carnê as posições  075 a 078 pedem o numero da parcela e o total de parcelas. 

 - Coloquei uma validação para o a propriedade tipoImpressao no banco Sicredi deve conter "A" ou "B"

Fiz também algumas adequações no canhoto do modo carnê de acordo com as sugestões do banco.