### PR TITLE
Correção boleto do bradesco para considerar o valor cobrado na linha digitável e no código de barras

### DIFF
--- a/src/.vs/config/applicationhost.config
+++ b/src/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Boleto.Net.Site" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\GITHUB\BoletoNet\src\Boleto.Net.Site" />
+                    <virtualDirectory path="/" physicalPath="D:\Projetos\boletonet\src\Boleto.Net.Site" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:3304:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="Boleto.Net.MVC" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\GITHUB\BoletoNet\src\Boleto.Net.MVC" />
+                    <virtualDirectory path="/" physicalPath="D:\Projetos\boletonet\src\Boleto.Net.MVC" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:26014:localhost" />

--- a/src/Boleto.Net.MVC/Controllers/HomeController.cs
+++ b/src/Boleto.Net.MVC/Controllers/HomeController.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Web.Mvc;
 using Boleto.Net.MVC.Models;
+using BoletoNet;
 
 namespace Boleto.Net.MVC.Controllers
 {
@@ -15,76 +14,69 @@ namespace Boleto.Net.MVC.Controllers
         public ActionResult Index()
         {
             ViewBag.Message = "Boleto.Net.MVC";
-
             var bancos = from Bancos s in Enum.GetValues(typeof(Bancos))
-                         select new { ID = Convert.ChangeType(s, typeof(int)), Name = s.ToString() };
+                         select new
+                         {
+                             ID = Convert.ChangeType(s, typeof(int)),
+                             Name = s.ToString()
+                         };
             ViewData["bancos"] = new SelectList(bancos, "ID", "Name", Bancos.BancodoBrasil);
-
             return View();
         }
 
         public ActionResult VisualizarBoleto(int Id)
         {
-            Exemplos exemplos = new Exemplos(Id);
+            var boleto = ObterBoletoBancario(Id);
+            ViewBag.Boleto = boleto.MontaHtmlEmbedded();
+            return View();
+        }
+
+        public ActionResult GerarBoletoPDF(int Id)
+        {
+            var boleto = ObterBoletoBancario(Id);
+            var pdf = boleto.MontaBytesPDF();
+            return File(pdf, "application/pdf");
+        }
+
+        public BoletoBancario ObterBoletoBancario(int Id)
+        {
+            var exemplos = new Exemplos(Id);
 
             switch ((Bancos)Id)
             {
                 case Bancos.BancodoBrasil:
-                    ViewBag.Boleto = exemplos.BancodoBrasil();
-                    break;
+                    return exemplos.BancodoBrasil();
                 case Bancos.Banrisul:
-                    ViewBag.Boleto = exemplos.Banrisul();
-                    break;
+                    return exemplos.Banrisul();
                 case Bancos.Basa:
-                    ViewBag.Boleto = exemplos.Basa();
-                    break;
+                    return exemplos.Basa();
                 case Bancos.Bradesco:
-                    ViewBag.Boleto = exemplos.Bradesco();
-                    break;
+                    return exemplos.Bradesco();
                 case Bancos.BRB:
-                    ViewBag.Boleto = exemplos.BRB();
-                    break;
+                    return exemplos.BRB();
                 case Bancos.Caixa:
-                    ViewBag.Boleto = exemplos.Caixa();
-                    break;
+                    return exemplos.Caixa();
                 case Bancos.HSBC:
-                    ViewBag.Boleto = exemplos.HSBC();
-                    break;
+                    return exemplos.HSBC();
                 case Bancos.Itau:
-                    ViewBag.Boleto = exemplos.Itau();
-                    break;
+                    return exemplos.Itau();
                 case Bancos.Real:
-                    ViewBag.Boleto = exemplos.Real();
-                    break;
+                    return exemplos.Real();
                 case Bancos.Safra:
-                    ViewBag.Boleto = exemplos.Safra();
-                    break;
+                    return exemplos.Safra();
                 case Bancos.Santander:
-                    ViewBag.Boleto = exemplos.Santander();
-                    break;
+                    return exemplos.Santander();
                 case Bancos.Sicoob:
-                    ViewBag.Boleto = exemplos.Sicoob();
-                    break;
+                    return exemplos.Sicoob();
                 case Bancos.Sicred:
-                    ViewBag.Boleto = exemplos.Sicred();
-                    break;
+                    return exemplos.Sicred();
                 case Bancos.Sudameris:
-                    ViewBag.Boleto = exemplos.Sudameris();
-                    break;
+                    return exemplos.Sudameris();
                 case Bancos.Unibanco:
-                    ViewBag.Boleto = exemplos.Unibanco();
-                    break;
+                    return exemplos.Unibanco();
                 default:
-                    ViewBag.Boleto = "Banco não implementado";
-                    break;
+                    throw new ArgumentException("Banco não implementado");
             }
-            return View();
-        }
-
-        public FileResult GeraPDF()
-        {
-            Exemplos exemplos = new Exemplos(341);
-            return File(exemplos.ItauPDF(), "application/pdf");
         }
     }
 }

--- a/src/Boleto.Net.MVC/Models/Exemplos.cs
+++ b/src/Boleto.Net.MVC/Models/Exemplos.cs
@@ -26,6 +26,7 @@ namespace Boleto.Net.MVC.Models
         Sudameris = 347,
         Unibanco = 409
     }
+
     /// <Author>
     /// Sandro Ribeiro - CODTEC SISTEMAS
     /// </Author>
@@ -37,7 +38,8 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.CodigoBanco = (short)Banco;
         }
         public BoletoBancario boletoBancario { get; set; }
-        public string BancodoBrasil()
+
+        public BoletoBancario BancodoBrasil()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -121,10 +123,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.RemoveSimboloMoedaValorDocumento = true;
             boletoBancario.AjustaTamanhoFonte(12, 10, 14, 14);
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Banrisul()
+        public BoletoBancario Banrisul()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -154,10 +156,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Basa()
+        public BoletoBancario Basa()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -195,10 +197,10 @@ namespace Boleto.Net.MVC.Models
             //boletoBancario.AjustaTamanhoFonte(12, tamanhoFonteInstrucaoImpressao: 14);
             boletoBancario.RemoveSimboloMoedaValorDocumento = false;
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Bradesco()
+        public BoletoBancario Bradesco()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -209,7 +211,9 @@ namespace Boleto.Net.MVC.Models
 
 
             //Carteiras 
-            BoletoNet.Boleto b = new BoletoNet.Boleto(vencimento, 1.01m, "09", "01000000001", c);
+            BoletoNet.Boleto b = new BoletoNet.Boleto(vencimento, 1.00m, "09", "01000000001", c);
+            b.ValorMulta = 0.10m;
+            b.ValorCobrado = 1.10m;
             b.NumeroDocumento = "01000000001";
             b.DataVencimento = new DateTime(2015, 09, 12);
 
@@ -237,10 +241,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string BRB()
+        public BoletoBancario BRB()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -265,10 +269,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Caixa()
+        public BoletoBancario Caixa()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -307,10 +311,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string HSBC()
+        public BoletoBancario HSBC()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -331,10 +335,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Itau()
+        public BoletoBancario Itau()
         {
             DateTime vencimento = DateTime.Now.AddDays(1);
 
@@ -373,10 +377,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Real()
+        public BoletoBancario Real()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -402,10 +406,10 @@ namespace Boleto.Net.MVC.Models
             EspeciesDocumento ed = EspecieDocumento_Real.CarregaTodas();
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Safra()
+        public BoletoBancario Safra()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -437,10 +441,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Santander()
+        public BoletoBancario Santander()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -472,10 +476,10 @@ namespace Boleto.Net.MVC.Models
 
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Sicoob()
+        public BoletoBancario Sicoob()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -499,10 +503,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Sicred()
+        public BoletoBancario Sicred()
         {
 
             DateTime vencimento = DateTime.Now.AddDays(1);
@@ -534,10 +538,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Sudameris()
+        public BoletoBancario Sudameris()
         {
             DateTime vencimento = DateTime.Now.AddDays(10);
 
@@ -568,10 +572,10 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
+            return boletoBancario;
         }
 
-        public string Unibanco()
+        public BoletoBancario Unibanco()
         {
             // ----------------------------------------------------------------------------------------
             // Exemplo 1
@@ -614,49 +618,7 @@ namespace Boleto.Net.MVC.Models
             boletoBancario.Boleto = b;
             boletoBancario.Boleto.Valida();
 
-            return boletoBancario.MontaHtmlEmbedded();
-        }
-
-        public byte[] ItauPDF()
-        {
-            DateTime vencimento = DateTime.Now.AddDays(1);
-
-            Instrucao_Itau item1 = new Instrucao_Itau(9, 5);
-            Instrucao_Itau item2 = new Instrucao_Itau(81, 10);
-            Cedente c = new Cedente("10.823.650/0001-90", "SAFIRALIFE", "4406", "22324");
-            //Na carteira 198 o código do Cedente é a conta bancária
-            c.Codigo = "13000";
-
-            BoletoNet.Boleto b = new BoletoNet.Boleto(vencimento, 0.1m, "176", "00000001", c, new EspecieDocumento(341, "1"));
-            b.NumeroDocumento = "00000001";
-
-            b.Sacado = new Sacado("000.000.000-00", "Nome do seu Cliente ");
-            b.Sacado.Endereco.End = "Endereço do seu Cliente ";
-            b.Sacado.Endereco.Bairro = "Bairro";
-            b.Sacado.Endereco.Cidade = "Cidade";
-            b.Sacado.Endereco.CEP = "00000000";
-            b.Sacado.Endereco.UF = "UF";
-
-            // Exemplo de como adicionar mais informações ao sacado
-            b.Sacado.InformacoesSacado.Add(new InfoSacado("TÍTULO: " + "2541245"));
-
-            item2.Descricao += " " + item2.QuantidadeDias.ToString() + " dias corridos do vencimento.";
-            b.Instrucoes.Add(item1);
-            b.Instrucoes.Add(item2);
-
-            // juros/descontos
-
-            if (b.ValorDesconto == 0)
-            {
-                Instrucao_Itau item3 = new Instrucao_Itau(999, 1);
-                item3.Descricao += ("1,00 por dia de antecipação.");
-                b.Instrucoes.Add(item3);
-            }
-
-            boletoBancario.Boleto = b;
-            boletoBancario.Boleto.Valida();
-
-            return boletoBancario.MontaBytesPDF();
+            return boletoBancario;
         }
     }
 }

--- a/src/Boleto.Net.MVC/Views/Home/Index.cshtml
+++ b/src/Boleto.Net.MVC/Views/Home/Index.cshtml
@@ -7,24 +7,26 @@
     e as regras estão sendo implementadas aos poucos.
 </p>
 <p>
-    Escolha um banco:@Html.DropDownList("bancos")</p>
-<div id="BoletoCarregado">
-</div>
+    Escolha um banco:@Html.DropDownList("bancos")
+    <button id="btnVisualizar">Visualizar</button>
+    <button id="btnGerarPDF">GerarPDF</button>
+</p>
+
 <script type="text/javascript">
     $(document).ready(function () {
 
-        $("#bancos").change(function () {
-            var strSelected = "";
-            $("#bancos option:selected").each(function () {
-                strSelected += $(this)[0].value;
-            });
-            var url = "/Home/VisualizarBoleto/" + strSelected;
-
-            //            $.post(url, function (data) {
-            //                $("#BoletoCarregado").html(data);
-            //            });
-
-            window.open(url, "WindowPopup", 'width=668,height=780');
+        $("#btnVisualizar").click(function () {
+            var url = "/Home/VisualizarBoleto/" + $("#bancos").val();
+            abrirPopup(url);
         });
+
+        $("#btnGerarPDF").click(function () {
+            var url = "/Home/GerarBoletoPDF/" + $("#bancos").val();
+            abrirPopup(url);
+        });
+
+        function abrirPopup(url) {
+            window.open(url, "WindowPopup", 'width=668,height=780');
+        }
     });
 </script>

--- a/src/Boleto.Net.Testes/BancoBradescoTeste.cs
+++ b/src/Boleto.Net.Testes/BancoBradescoTeste.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
@@ -83,6 +82,22 @@ namespace BoletoNet.Testes
             return boletoBancario;
         }
 
+        private BoletoBancario GerarBoletoComValorCobradoCarteira09()
+        {
+            var vencimento = new DateTime(2012, 6, 8);
+            var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0539", "8", "0032463", "9");
+
+            var boleto = new Boleto(vencimento, 5000, "09", "18194", cedente);
+            boleto.NumeroDocumento = "18194";
+            boleto.ValorMulta = 100;
+            boleto.ValorCobrado = 5100;
+
+            var boletoBancario = new BoletoBancario();
+            boletoBancario.CodigoBanco = 237;
+            boletoBancario.Boleto = boleto;
+            return boletoBancario;
+        }
+
         [TestMethod]
         public void Bradesco_Carteira_09_NossoNumero()
         {
@@ -108,6 +123,18 @@ namespace BoletoNet.Testes
         }
 
         [TestMethod]
+        public void Bradesco_Carteira_09_LinhaDigitavel_ValorCobrado()
+        {
+            var boletoBancario = GerarBoletoComValorCobradoCarteira09();
+
+            boletoBancario.Boleto.Valida();
+
+            var linhaDigitavelValida = "23790.53909 90000.001819 94003.246306 1 53580000510000";
+
+            Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
+        }
+
+        [TestMethod]
         public void Bradesco_Carteira_09_CodigoBarra()
         {
             var boletoBancario = GerarBoletoCarteira09();
@@ -115,6 +142,18 @@ namespace BoletoNet.Testes
             boletoBancario.Boleto.Valida();
 
             string codigoBarraValida = "23793535800007620000539090000001819400324630";
+
+            Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
+        }
+
+        [TestMethod]
+        public void Bradesco_Carteira_09_CodigoBarra_ValorCobrado()
+        {
+            var boletoBancario = GerarBoletoComValorCobradoCarteira09();
+
+            boletoBancario.Boleto.Valida();
+
+            var codigoBarraValida = "23791535800005100000539090000001819400324630";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }

--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -116,7 +116,8 @@ namespace BoletoNet
             //if (boleto.Carteira == "06" && !Utils.DataValida(boleto.DataVencimento))
             //    FFFF = "0000";
 
-            string VVVVVVVVVV = boleto.ValorBoleto.ToString("N2").Replace(",", "").Replace(".", "");
+            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
+            string VVVVVVVVVV = valor.ToString("N2").Replace(",", "").Replace(".", "");
             VVVVVVVVVV = Utils.FormatCode(VVVVVVVVVV, 10);
 
             //if (Utils.ToInt64(VVVVVVVVVV) == 0)
@@ -148,7 +149,8 @@ namespace BoletoNet
         /// 
         public override void FormataCodigoBarra(Boleto boleto)
         {
-            var valorBoleto = boleto.ValorBoleto.ToString("N2").Replace(",", "").Replace(".", "");
+            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
+            var valorBoleto = valor.ToString("N2").Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
             if (boleto.Carteira == "02" || boleto.Carteira == "03" || boleto.Carteira == "09" || boleto.Carteira == "19" || boleto.Carteira == "26") // Com registro
@@ -210,6 +212,7 @@ namespace BoletoNet
         {
             boleto.NossoNumero = string.Format("{0}/{1}-{2}", Utils.FormatCode(boleto.Carteira, 3), boleto.NossoNumero, boleto.DigitoNossoNumero);
         }
+
         public override string GerarHeaderRemessa(string numeroConvenio, Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa, Boleto boletos)
         {
             throw new NotImplementedException("Função não implementada.");

--- a/src/Boleto.Net/Boleto/Boleto.cs
+++ b/src/Boleto.Net/Boleto/Boleto.cs
@@ -87,7 +87,6 @@ namespace BoletoNet
 			this._nossoNumero = nossoNumero;
 			this._dataVencimento = dataVencimento;
 			this._valorBoleto = valorBoleto;
-			this._valorBoleto = valorBoleto;
 			this._valorCobrado = this.ValorCobrado;
 			this._cedente = cedente;
 
@@ -98,7 +97,6 @@ namespace BoletoNet
 		{
 			this._carteira = carteira;
 			this._nossoNumero = nossoNumero;
-			this._valorBoleto = valorBoleto;
 			this._valorBoleto = valorBoleto;
 			this._valorCobrado = this.ValorCobrado;
 			this._cedente = cedente;
@@ -122,7 +120,6 @@ namespace BoletoNet
 			this._digitoNossoNumero = digitoNossoNumero;
 			this._dataVencimento = dataVencimento;
 			this._valorBoleto = valorBoleto;
-			this._valorBoleto = valorBoleto;
 			this._valorCobrado = this.ValorCobrado;
 			this._cedente = cedente;
 		}
@@ -132,7 +129,6 @@ namespace BoletoNet
 			this._carteira = carteira;
 			this._nossoNumero = nossoNumero;
 			this._dataVencimento = dataVencimento;
-			this._valorBoleto = valorBoleto;
 			this._valorBoleto = valorBoleto;
 			this._valorCobrado = this.ValorCobrado;
 			this._cedente = new Cedente(new ContaBancaria(agencia, conta));

--- a/src/Boleto.Net/BoletoImpressao/BoletoNet.css
+++ b/src/Boleto.Net/BoletoImpressao/BoletoNet.css
@@ -347,6 +347,7 @@ img {
 	font: bold 10px arial;
 	color: black;
 	height: 12px;
+    text-align: right;
 }
 
 .mt23 {

--- a/src/Boleto.Net/BoletoImpressao/BoletoNetPDF.css
+++ b/src/Boleto.Net/BoletoImpressao/BoletoNetPDF.css
@@ -109,6 +109,7 @@ img {
 	.imgLogo img {
 		width: 150px;
 		height: 40px;
+        margin-bottom: 1px;
 	}
 
 .barra {
@@ -195,7 +196,7 @@ img {
 }
 
 .w72 {
-	width: 72px;
+	width: 74px;
 }
 
 .w83 {
@@ -347,6 +348,7 @@ img {
 	font: bold 10px arial;
 	color: black;
 	height: 12px;
+    text-align: right;
 }
 
 .mt23 {


### PR DESCRIPTION
Boa tarde,
Fiz a correção da geração do boleto bradesco o qual irei utilizar agora, acredito que possamos continuar a revisão os outros boletos quando o boleto tem valor cobrado.
Fiz a correção e adicionei mais 2 testes unitários para o valor cobrado, nenhum teste que já existia foi quebrado.
Aproveitei também e adicionei no projeto de teste a geração por PDF, continuei na mesma pegada que já existia mais precisou de algumas alterações para não duplicar código.
Segue imagem abaixo como a tela de teste ficou:

![imagem sem titulo](https://user-images.githubusercontent.com/4171999/31192697-5f315376-a918-11e7-8449-ec8bf238e50a.png)
