### PR TITLE
Correção no método Right na classe Extensions.cs

### DIFF
--- a/src/Boleto.Net/Util/Extensions.cs
+++ b/src/Boleto.Net/Util/Extensions.cs
@@ -90,7 +90,7 @@ namespace BoletoNet.Util
 
         public static string Right(this string str, int length)
         {
-            return str.Substring(str.Length - length);
+            return str.Substring(length >= str.Length ? str : str.Length - length);
         }
 
     }

--- a/src/Boleto.Net/Util/Extensions.cs
+++ b/src/Boleto.Net/Util/Extensions.cs
@@ -90,7 +90,7 @@ namespace BoletoNet.Util
 
         public static string Right(this string str, int length)
         {
-            return str.Substring(length >= str.Length ? str : str.Length - length);
+            return str.Substring(length >= str.Length ? 0 : str.Length - length);
         }
 
     }


### PR DESCRIPTION
Correção no método Right na classe Extensions.cs, pois está ocorrendo problema quando o tamanho da string passada por parâmetro é menor que o tamanho passado no segundo parâmetro, ocasionando erro ao obter a substring.

Sugerida correção conforme era feito quando se utilizava o método Strings.Right do namespace Microsoft.VisualBasic;