### PR TITLE
Alterações para Espécie de Documento

### DIFF
--- a/src/.vs/config/applicationhost.config
+++ b/src/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Boleto.Net.Site" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Projetos\boletonet\src\Boleto.Net.Site" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\diego.QBIT\Documents\Visual Studio 2015\Projects\boletonet\src\Boleto.Net.Site" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:3304:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="Boleto.Net.MVC" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Projetos\boletonet\src\Boleto.Net.MVC" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\diego.QBIT\Documents\Visual Studio 2015\Projects\boletonet\src\Boleto.Net.MVC" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:26014:localhost" />

--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -1027,7 +1027,7 @@ namespace BoletoNet
                 string vInstrucao1 = "00"; //1ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
                 string vInstrucao2 = "00"; //2ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
 
-                foreach (Instrucao_Bradesco instrucao in boleto.Instrucoes)
+                foreach (Instrucao instrucao in boleto.Instrucoes)
                 {
                     switch ((EnumInstrucoes_Bradesco)instrucao.Codigo)
                     {

--- a/src/Boleto.Net/Boleto/EspecieDocumento/AbstractEspecieDocumento.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/AbstractEspecieDocumento.cs
@@ -44,5 +44,7 @@ namespace BoletoNet
         # endregion
 
         public abstract IEspecieDocumento DuplicataMercantil();
+
+        public abstract string getCodigoEspecieBySigla(string sigla);
     }
 }

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento.cs
@@ -44,6 +44,20 @@ namespace BoletoNet
             }
         }
 
+        public EspecieDocumento(string CodigoBanco, string sigla)
+        {
+            try
+            {
+                int codBanco = Convert.ToInt32(CodigoBanco);
+
+                InstanciaEspecieDocumento(codBanco, getCodigoEspecieBySigla(codBanco, sigla));
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao instanciar objeto.", ex);
+            }
+        }
+
         #endregion
 
         #region Propriedades da interface
@@ -107,6 +121,7 @@ namespace BoletoNet
                     case 237:
                         _IEspecieDocumento = new EspecieDocumento_Bradesco(codigoEspecie);
                         break;
+                    //356 - Real
                     case 356:
                         _IEspecieDocumento = new EspecieDocumento_Real(codigoEspecie);
                         break;
@@ -114,6 +129,7 @@ namespace BoletoNet
                     case 33:
                         _IEspecieDocumento = new EspecieDocumento_Santander(codigoEspecie);
                         break;
+                    //347 - Sudameris
                     case 347:
                         _IEspecieDocumento = new EspecieDocumento_Sudameris(codigoEspecie);
                         break;
@@ -141,7 +157,7 @@ namespace BoletoNet
                     case 756:
                         _IEspecieDocumento = new EspecieDocumento_Sicoob(codigoEspecie);
                         break;
-                    //004 Banco do Nordeste
+                    //004 - Banco do Nordeste
                     case 4:
                         _IEspecieDocumento = new EspecieDocumento_Nordeste(codigoEspecie);
                         break;
@@ -149,12 +165,15 @@ namespace BoletoNet
                     case 655:
                         _IEspecieDocumento = new EspecieDocumento_Votorantim(codigoEspecie);
                         break;
+                    //707 - Daycoval
                     case 707:
                         _IEspecieDocumento = new EspecieDocumento_Daycoval(codigoEspecie);
                         break;
+                    //637 - Sofisa
                     case 637:
                         _IEspecieDocumento = new EspecieDocumento_Sofisa(codigoEspecie);
                         break;
+                    //21 - Banestes
                     case 21:
                         _IEspecieDocumento = new EspecieDocumento_Banestes(codigoEspecie);
                         break;
@@ -251,6 +270,84 @@ namespace BoletoNet
                 throw new BoletoNetException("Espécies de documentos não implementados para o banco.");
 
             return especiesDocumentosBancos[banco.Codigo].DuplicataMercantil();
+        }
+
+        private string getCodigoEspecieBySigla(int codigoBanco, string sigla)
+        {
+
+            try
+            {
+                switch (codigoBanco)
+                {
+                    //341 - Itaú
+                    case 341:
+                        return new EspecieDocumento_Itau().getCodigoEspecieBySigla(sigla);
+                    //479 - BankBoston
+                    case 479:
+                        return new EspecieDocumento_BankBoston().getCodigoEspecieBySigla(sigla);
+                    //422 - Safra
+                    case 1:
+                        return new EspecieDocumento_BancoBrasil().getCodigoEspecieBySigla(sigla);
+                    //237 - Bradesco
+                    case 237:
+                        return new EspecieDocumento_Bradesco().getCodigoEspecieBySigla(sigla);
+                    //356 - Real
+                    case 356:
+                        return new EspecieDocumento_Real().getCodigoEspecieBySigla(sigla);
+                    //033 - Santander
+                    case 33:
+                        return new EspecieDocumento_Santander().getCodigoEspecieBySigla(sigla);
+                    //347 - Sudameris
+                    case 347:
+                        return new EspecieDocumento_Sudameris().getCodigoEspecieBySigla(sigla);
+                    //104 - Caixa
+                    case 104:
+                        return new EspecieDocumento_Caixa().getCodigoEspecieBySigla(sigla);
+                    //399 - HSBC
+                    case 399:
+                        return new EspecieDocumento_HSBC().getCodigoEspecieBySigla(sigla);
+                    //748 - Sicredi
+                    case 748:
+                        return new EspecieDocumento_Sicredi().getCodigoEspecieBySigla(sigla);
+                    //41 - Banrisul - sidneiklein
+                    case 41:
+                        return new EspecieDocumento_Banrisul().getCodigoEspecieBySigla(sigla);
+                    //085 - Cecred
+                    case 85:
+                        return new EspecieDocumento_Cecred().getCodigoEspecieBySigla(sigla);
+                    //756 - Sicoob
+                    case 756:
+                        return new EspecieDocumento_Sicoob().getCodigoEspecieBySigla(sigla);
+                    //004 Banco do Nordeste
+                    case 4:
+                        return new EspecieDocumento_Nordeste().getCodigoEspecieBySigla(sigla);
+                    //655 - Votorantim
+                    case 655:
+                        return new EspecieDocumento_Votorantim().getCodigoEspecieBySigla(sigla);
+                    //707 - Daycoval
+                    case 707:
+                        return new EspecieDocumento_Daycoval().getCodigoEspecieBySigla(sigla);
+                    //637 - Sofisa
+                    case 637:
+                        return new EspecieDocumento_Sofisa().getCodigoEspecieBySigla(sigla);
+                    //21 - Banestes
+                    case 21:
+                        return new EspecieDocumento_Banestes().getCodigoEspecieBySigla(sigla);
+                    //97 - CrediSis
+                    case 97:
+                        return new EspecieDocumento_CrediSIS().getCodigoEspecieBySigla(sigla);
+                    //743 - Semear
+                    case 743:
+                        return new EspecieDocumento_Semear().getCodigoEspecieBySigla(sigla);
+                    default:
+                        throw new Exception("Código do banco não implementando: " + codigoBanco);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a execução da transação.", ex);
+            }
+        
         }
 
         private static Dictionary<int, AbstractEspecieDocumento> especiesDocumentosBancos = new Dictionary<int, AbstractEspecieDocumento>() {

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BancoBrasil.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BancoBrasil.cs
@@ -137,6 +137,40 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DMI": return "3";
+                case "DS": return "4";
+                case "DSI": return "5";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NCC": return "8";
+                case "NCE": return "9";
+                case "NCI" : return "10";
+                case "NCR": return "11";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "TM": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FAT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "OUTROS": return "23";
+                case "DAE": return "27";
+                case "DAM": return "28";
+                case "DAU": return "29";
+                default: return "0";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Banestes.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Banestes.cs
@@ -67,6 +67,16 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "OU": return "99";
+                default: return "1";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BankBoston.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_BankBoston.cs
@@ -84,6 +84,22 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "DS": return "2";
+                case "NS": return "3";
+                case "RE": return "4";
+                case "RS": return "5";
+                case "RC": return "6";
+                case "ND": return "7";
+                case "OT": return "8";
+                default: return "0";
+            }
+        }
+
         private void carregar(string Codigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Banrisul.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Banrisul.cs
@@ -129,6 +129,37 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DMI": return "3";
+                case "DS": return "4";
+                case "DSI": return "5";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NCC": return "8";
+                case "NCE": return "9";
+                case "NCI": return "10";
+                case "NCR": return "11";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "TM": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FAT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "OUTROS": return "23";
+                default: return "2";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Bradesco.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Bradesco.cs
@@ -74,7 +74,7 @@ namespace BoletoNet
         {
             switch (codigo)
             {
-                case "1": return EnumEspecieDocumento_Bradesco.DuplicataMercantil;
+                case "1" : return EnumEspecieDocumento_Bradesco.DuplicataMercantil;
                 case "2": return EnumEspecieDocumento_Bradesco.NotaPromissoria;
                 case "3": return EnumEspecieDocumento_Bradesco.NotaSeguro;
                 case "4": return EnumEspecieDocumento_Bradesco.CobrancaSeriada;
@@ -84,6 +84,22 @@ namespace BoletoNet
                 case "12": return EnumEspecieDocumento_Bradesco.DuplicataServico;
                 case "99": return EnumEspecieDocumento_Bradesco.Outros;
                 default: return EnumEspecieDocumento_Bradesco.Outros;
+            }
+        }
+
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NP": return "2";
+                case "NS": return "3";
+                case "CS": return "4";
+                case "RC": return "5";
+                case "LC": return "10";
+                case "ND": return "11";
+                case "DS": return "12";
+                default: return "99";
             }
         }
 

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Caixa.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Caixa.cs
@@ -77,6 +77,20 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NP": return "2";
+                case "DS": return "3";
+                case "NS": return "5";
+                case "LC": return "6";
+                case "OU": return "9";
+                default: return "1";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Cecred.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Cecred.cs
@@ -43,6 +43,18 @@ namespace BoletoNet {
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NF": return "2";
+                case "RC": return "5";
+                case "DS": return "12";             
+                default: return "1";
+            }
+        }
+
         private void carregar(string idCodigo) {
             try {
                 this.Banco = new Banco_Sicredi();

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_CrediSIS.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_CrediSIS.cs
@@ -78,6 +78,20 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DMI": return "3";
+                case "DSI": return "5";
+                case "NP": return "12";
+                case "RC": return "17";
+                case "ME": return "21";
+                case "NF": return "23";
+                default: return "5";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Daycoval.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Daycoval.cs
@@ -45,11 +45,46 @@ namespace BoletoNet
 			Outros = 99
 		}
 
-		#endregion
+        #endregion
 
-		#region Methods
+        #region Methods
 
-		private void carregar(string idCodigo)
+        private string RetornaCodigoEspecie(EnumEspecieDocumento_Daycoval especie)
+        {
+            return ((int)especie).ToString().PadLeft(2, '0');
+        }
+
+        private EnumEspecieDocumento_Daycoval RetornaEnumPorCodigo(string codigo)
+        {
+            switch (codigo)
+            {
+                case "01":
+                    return EnumEspecieDocumento_Daycoval.DuplicataMercantil;
+                case "05":
+                    return EnumEspecieDocumento_Daycoval.Recibo;
+                case "12":
+                    return EnumEspecieDocumento_Daycoval.DuplicataServico;
+                case "99":
+                    return EnumEspecieDocumento_Daycoval.Outros;
+
+                default:
+                    return EnumEspecieDocumento_Daycoval.DuplicataMercantil;
+            }
+        }
+
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "01";
+                case "RC": return "05";
+                case "DS": return "12";
+                case "OU": return "99";
+                default: return "01";
+            }
+        }
+
+        private void carregar(string idCodigo)
 		{
 			try
 			{
@@ -65,7 +100,7 @@ namespace BoletoNet
 					case EnumEspecieDocumento_Daycoval.Recibo:
 						this.Codigo = this.RetornaCodigoEspecie(EnumEspecieDocumento_Daycoval.Recibo);
 						this.Especie = "Recibo";
-						this.Sigla = "RE";
+						this.Sigla = "RC";
 						break;
 					case EnumEspecieDocumento_Daycoval.DuplicataServico:
 						this.Codigo = this.RetornaCodigoEspecie(EnumEspecieDocumento_Daycoval.DuplicataServico);
@@ -87,30 +122,7 @@ namespace BoletoNet
 			{
 				throw new Exception("Erro ao carregar objeto", ex);
 			}
-		}
-
-		private string RetornaCodigoEspecie(EnumEspecieDocumento_Daycoval especie)
-		{
-			return ((int)especie).ToString().PadLeft(2, '0');
-		}
-
-		private EnumEspecieDocumento_Daycoval RetornaEnumPorCodigo(string codigo)
-		{
-			switch (codigo)
-			{
-				case "01":
-					return EnumEspecieDocumento_Daycoval.DuplicataMercantil;
-				case "05":
-					return EnumEspecieDocumento_Daycoval.Recibo;
-				case "12":
-					return EnumEspecieDocumento_Daycoval.DuplicataServico;
-				case "99":
-					return EnumEspecieDocumento_Daycoval.Outros;
-
-				default:
-					return EnumEspecieDocumento_Daycoval.DuplicataMercantil;
-			}
-		}
+		}	
 
         public override IEspecieDocumento DuplicataMercantil()
         {

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_HSBC.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_HSBC.cs
@@ -141,6 +141,41 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DMI": return "3";
+                case "DS": return "4";
+                case "DSI": return "5";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NCC": return "8";
+                case "NCE": return "9";
+                case "NCI": return "10";
+                case "NCR": return "11";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "TM": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FAT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "NF": return "23";
+                case "DD": return "24";
+                case "CEC": return "98";
+                case "OUTROS": return "99";
+                case "PD": return "0";
+                default: return "99";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Itau.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Itau.cs
@@ -99,6 +99,26 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NP": return "2";
+                case "NS": return "3";
+                case "ME": return "4";
+                case "RC": return "5";
+                case "C": return "6";
+                case "CS": return "7";
+                case "DS": return "8";
+                case "LC": return "9";
+                case "ND": return "13";
+                case "DD": return "15";
+                case "EC": return "16";
+                default: return "99";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try
@@ -130,17 +150,17 @@ namespace BoletoNet
                     case EnumEspecieDocumento_Itau.Recibo:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Itau.Recibo);
                         this.Especie = "Recibo";
-                        this.Sigla = "NS";
+                        this.Sigla = "RC";
                         break;
                     case EnumEspecieDocumento_Itau.Contrato:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Itau.Contrato);
-                        this.Sigla = "C";
                         this.Especie = "Contrato";
+                        this.Sigla = "C";
                         break;
                     case EnumEspecieDocumento_Itau.Cosseguros:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Itau.Cosseguros);
-                        this.Sigla = "CS";
                         this.Especie = "Cosseguros";
+                        this.Sigla = "CS";
                         break;
                     case EnumEspecieDocumento_Itau.DuplicataServico:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Itau.DuplicataServico);

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Nordeste.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Nordeste.cs
@@ -81,6 +81,21 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "01";
+                case "NP": return "02";
+                case "CH": return "03";
+                case "CR": return "04";
+                case "RC": return "05";
+                case "DS": return "06";
+                case "OUTROS": return "19";
+                default: return "01";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try
@@ -122,7 +137,7 @@ namespace BoletoNet
                     case EnumEspecieDocumento_Nordeste.Carne:
                         this.Codigo = getCodigoEspecieByEnum(EnumEspecieDocumento_Nordeste.Carne);
                         this.Especie = "CARNE";
-                        this.Sigla = "";
+                        this.Sigla = "CR";
                         break;
                     default:
                         this.Codigo = "0";

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Real.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Real.cs
@@ -130,6 +130,37 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DMI": return "3";
+                case "DS": return "4";
+                case "DSI": return "5";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NCC": return "8";
+                case "NCE": return "9";
+                case "NCI": return "10";
+                case "NCR": return "11";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "TM": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FAT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "C016": return "23";
+                default: return "2";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Santander.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Santander.cs
@@ -100,6 +100,23 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "2";
+                case "DS": return "4";
+                case "LS": return "7";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "RC": return "17";
+                case "AP": return "20";
+                case "CH": return "97";
+                case "ND": return "98";
+                default: return "2";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Semear.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Semear.cs
@@ -85,6 +85,23 @@ namespace BoletoNet
             }
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NP": return "2";
+                case "NS": return "3";
+                case "CS": return "4";
+                case "RC": return "5";
+                case "LC": return "10";
+                case "ND": return "11";
+                case "DS": return "12";
+                case "OU": return "99";
+                default: return "1";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicoob.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicoob.cs
@@ -78,6 +78,30 @@ namespace BoletoNet
             return (EnumEspecieDocumento_Sicoob) Convert.ToInt32(codigo);
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DS": return "4";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NP": return "12";
+                case "TP": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "OU": return "23";              
+                default: return "2";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicredi.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sicredi.cs
@@ -87,7 +87,25 @@ namespace BoletoNet
                 default: return EnumEspecieDocumento_Sicredi.Outros;
             }
         }
-        
+
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DMI": return "A";
+                case "DR": return "B";
+                case "NP": return "C";
+                case "NPR": return "D";
+                case "NS": return "E";
+                case "RC": return "G";
+                case "LC": return "H";
+                case "ND": return "I";
+                case "DSI": return "J";
+                case "OS": return "K";
+                default: return "K";
+            }
+        }
+
         #region Metodos Privados
 
         private void carregar(string idCodigo)

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sofisa.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sofisa.cs
@@ -68,7 +68,7 @@ namespace BoletoNet
 					case EnumEspecieDocumento_Sofisa.Recibo:
 						this.Codigo = this.RetornaCodigoEspecie(EnumEspecieDocumento_Sofisa.Recibo);
 						this.Especie = "Recibo";
-						this.Sigla = "RE";
+						this.Sigla = "RC";
 						break;
 					case EnumEspecieDocumento_Sofisa.DuplicataServico:
 						this.Codigo = this.RetornaCodigoEspecie(EnumEspecieDocumento_Sofisa.DuplicataServico);
@@ -142,6 +142,22 @@ namespace BoletoNet
 					return EnumEspecieDocumento_Sofisa.DuplicataMercantil;
 			}
 		}
+
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "01";
+                case "NP": return "02";
+                case "CH": return "03";
+                case "LC": return "04";
+                case "RC": return "05";
+                case "AS": return "08";
+                case "DS": return "12";
+                case "OU": return "99";
+                default: return "01";
+            }
+        }
 
         public override IEspecieDocumento DuplicataMercantil()
         {

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sudameris.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Sudameris.cs
@@ -98,7 +98,27 @@ namespace BoletoNet
                 default: return EnumEspecieDocumento_Sudameris.Diversos;
             }
         }
-        
+
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "DM": return "1";
+                case "NP": return "2";
+                case "NS": return "3";
+                case "ME": return "4";
+                case "RC": return "5";
+                case "C": return "6";
+                case "CS": return "7";
+                case "DS": return "8";
+                case "LC": return "9";
+                case "ND": return "13";
+                case "DD": return "15";
+                case "EC": return "16";
+                default: return "99";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try
@@ -131,7 +151,7 @@ namespace BoletoNet
                     case EnumEspecieDocumento_Sudameris.Recibo:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Sudameris.Recibo);
                         this.Especie = "Recibo";
-                        this.Sigla = "R";
+                        this.Sigla = "RC";
                         break;
                     case EnumEspecieDocumento_Sudameris.Contrato:
                         this.Codigo = ed.getCodigoEspecieByEnum(EnumEspecieDocumento_Sudameris.Contrato);

--- a/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Votorantim.cs
+++ b/src/Boleto.Net/Boleto/EspecieDocumento/EspecieDocumento_Votorantim.cs
@@ -76,6 +76,37 @@ namespace BoletoNet
             return (EnumEspecieDocumento_Votorantim)Enum.ToObject(typeof(EnumEspecieDocumento_Votorantim), codigo);
         }
 
+        public override string getCodigoEspecieBySigla(string sigla)
+        {
+            switch (sigla)
+            {
+                case "CH": return "1";
+                case "DM": return "2";
+                case "DMI": return "3";
+                case "DS": return "4";
+                case "DSI": return "5";
+                case "DR": return "6";
+                case "LC": return "7";
+                case "NCC": return "8";
+                case "NCE": return "9";
+                case "NCI": return "10";
+                case "NCR": return "11";
+                case "NP": return "12";
+                case "NPR": return "13";
+                case "TM": return "14";
+                case "TS": return "15";
+                case "NS": return "16";
+                case "RC": return "17";
+                case "FAT": return "18";
+                case "ND": return "19";
+                case "AP": return "20";
+                case "ME": return "21";
+                case "PC": return "22";
+                case "OUTROS": return "23";
+                default: return "2";
+            }
+        }
+
         private void carregar(string idCodigo)
         {
             try

--- a/src/Boleto.Net/Properties/AssemblyInfo.cs
+++ b/src/Boleto.Net/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Web.UI;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the "*" as shown below:
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
 
 [assembly: TagPrefix("BoletoNet", "bn")]


### PR DESCRIPTION
Basicamente foram realizadas alterações para obter o código da espécie do documento pela sigla. Essas alterações não afetam o que já existia de tratamento de espécie. Aqui, trabalhamos sempre com a sigla do documento, por serem comuns na maioria dos bancos.
Foi corrigido também um bug ao colocar as instruções nos detalhes de remessa 400 do banco bradesco.