### PR TITLE
Permitir o uso de Instrucao do tipo especifica ao banco Bradesco

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -1027,7 +1027,7 @@ namespace BoletoNet
                 string vInstrucao1 = "00"; //1ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
                 string vInstrucao2 = "00"; //2ª instrução (2, N) Caso Queira colocar um cod de uma instrução. ver no Manual caso nao coloca 00
 
-                foreach (Instrucao instrucao in boleto.Instrucoes)
+                foreach (var instrucao in boleto.Instrucoes)
                 {
                     switch ((EnumInstrucoes_Bradesco)instrucao.Codigo)
                     {


### PR DESCRIPTION
Atualmente quando se atribui ao boleto instruções do tipo "Instrucao_Bradesco" esta gerando erro na conversão para "Instrucao" neste foreach :

"BoletoNet.Instrucao não pode ser convertido em BoletoNet.Instrucao_Bradesco"