### PR TITLE
Digito verficador nosso número Sicredi

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Sicredi.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicredi.cs
@@ -600,10 +600,21 @@ namespace BoletoNet
             return d;
         }
 
-        public string DigNossoNumeroSicredi(Boleto boleto)
+        public string DigNossoNumeroSicredi(Boleto boleto, bool arquivoRemessa = false)
         {
-            string codigoCedente = boleto.Cedente.Codigo;           //código do beneficiário aaaappccccc
-            string nossoNumero = boleto.NossoNumero;                //ano atual (yy), indicador de geração do nosso número (b) e o número seqüencial do beneficiário (nnnnn);
+            //Adicionado por diego.dariolli pois ao gerar remessa o dígito saía errado pois faltava agência e posto no código do cedente
+            string codigoCedente = ""; //código do beneficiário aaaappccccc
+            if (arquivoRemessa)
+            {
+                if (string.IsNullOrEmpty(boleto.Cedente.ContaBancaria.OperacaConta))
+                    throw new Exception("O código do posto beneficiário não foi informado.");
+
+                codigoCedente = string.Concat(boleto.Cedente.ContaBancaria.Agencia, boleto.Cedente.ContaBancaria.OperacaConta, boleto.Cedente.Codigo); 
+            }
+            else
+                codigoCedente = boleto.Cedente.Codigo;
+
+            string nossoNumero = boleto.NossoNumero; //ano atual (yy), indicador de geração do nosso número (b) e o número seqüencial do beneficiário (nnnnn);
 
             string seq = string.Concat(codigoCedente, nossoNumero); // = aaaappcccccyybnnnnn
             /* Variáveis
@@ -839,7 +850,7 @@ namespace BoletoNet
                 string vAuxNossoNumeroComDV = NossoNumero;
                 if (string.IsNullOrEmpty(boleto.DigitoNossoNumero) || NossoNumero.Length < 9)
                 {
-                    boleto.DigitoNossoNumero = DigNossoNumeroSicredi(boleto);
+                    boleto.DigitoNossoNumero = DigNossoNumeroSicredi(boleto, true);
                     vAuxNossoNumeroComDV = NossoNumero + boleto.DigitoNossoNumero;
                 }
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0048, 009, 0, vAuxNossoNumeroComDV, '0'));                      //048-056


### PR DESCRIPTION
Ao gerar remessa, a variável de código do cedente não era preenchida com a agência e código do posto (somente quando gerava o boleto), então o digito saía errado