### PR TITLE
Alteração no calculo do digito verificador do nosso número.

### DIFF
--- a/src/Boleto.Net.Testes/BancoSantanderTeste.cs
+++ b/src/Boleto.Net.Testes/BancoSantanderTeste.cs
@@ -36,7 +36,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string nossoNumeroValido = "000000020061-1";
+            string nossoNumeroValido = "000000020061-0";
 
             Assert.AreEqual(boletoBancario.Boleto.NossoNumero, nossoNumeroValido, "Nosso número inválido");
         }
@@ -48,7 +48,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "03399.33095 89400.000009 20061.101018 1 55370000270140";
+            string linhaDigitavelValida = "03399.33095 89400.000009 20061.001010 6 55370000270140";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -97,7 +97,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "03399.37807 45700.000024 52084.281014 8 56770000105250";
+            string linhaDigitavelValida = "03399.37807 45700.000024 52084.181016 3 56770000105250";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -109,7 +109,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarra = "03398567700001052509378045700000025208428101";
+            string codigoBarra = "03393567700001052509378045700000025208418101";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarra, "Código de Barra inválido");
         }

--- a/src/Boleto.Net.Testes/Retorno/NossoNumeroRetornoTeste.cs
+++ b/src/Boleto.Net.Testes/Retorno/NossoNumeroRetornoTeste.cs
@@ -70,7 +70,7 @@ namespace Boleto.Net.Testes.Retorno
         {
             var convenio = 1234567;
             var nossoNumero = 100003147578;
-            var dv = 7;
+            var dv = 6;
 
             var nossoNumeroRetorno = string.Format("{0}{1}", nossoNumero, dv);
 

--- a/src/Boleto.Net/Banco/Banco_Santander.cs
+++ b/src/Boleto.Net/Banco/Banco_Santander.cs
@@ -69,7 +69,7 @@ namespace BoletoNet
             string valorNominal = Utils.FormatCode(boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", ""), 10);//10
             string fixo = "9";//1
             string codigoCedente = Utils.FormatCode(boleto.Cedente.Codigo.ToString(), 7);//7
-            string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12), 9);//13
+            string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12));//13
             string IOS = boleto.PercentualIOS.ToString();//1
             string tipoCarteira = boleto.Carteira;//3;
             boleto.CodigoBarra.Codigo = string.Format("{0}{1}{2}{3}{4}{5}{6}{7}{8}",
@@ -113,7 +113,7 @@ namespace BoletoNet
         /// </summary>
         public override void FormataLinhaDigitavel(Boleto boleto)
         {
-            string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12), 9);//13
+            string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12));//13
             string codigoCedente = Utils.FormatCode(boleto.Cedente.Codigo.ToString(), 7);
             string fatorVencimento = FatorVencimento(boleto).ToString();
             string IOS = boleto.PercentualIOS.ToString();//1
@@ -156,7 +156,7 @@ namespace BoletoNet
             string DVvalorNominal = Utils.FormatCode(boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", ""), 10);//10
             string DVfixo = "9";//1
             string DVcodigoCedente = Utils.FormatCode(boleto.Cedente.Codigo.ToString(), 7).ToString();//7
-            string DVnossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12), 9);
+            string DVnossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12));
             string DVtipoCarteira = boleto.Carteira;//3;
 
             string calculoDVcodigo = string.Format("{0}{1}{2}{3}{4}{5}{6}{7}{8}",
@@ -183,7 +183,7 @@ namespace BoletoNet
 
         public override void FormataNossoNumero(Boleto boleto)
         {
-            boleto.NossoNumero = string.Format("{0}-{1}", boleto.NossoNumero, Mod11Santander(boleto.NossoNumero, 9));
+            boleto.NossoNumero = string.Format("{0}-{1}", boleto.NossoNumero, Mod11Santander(boleto.NossoNumero));
         }
 
         public override void FormataNumeroDocumento(Boleto boleto)
@@ -239,37 +239,31 @@ namespace BoletoNet
             boleto.FormataCampos();
         }
 
-        private static int Mod11Santander(string seq, int lim)
+        private static int Mod11Santander(string nossoNumero)
         {
-            int ndig = 0;
-            int nresto = 0;
-            int total = 0;
-            int multiplicador = 5;
+            var digito = 0;
+            var multiplicador = 2;
+            var total = 0;
+            var nossoNumeroArray = nossoNumero.ToCharArray().Reverse();
 
-            while (seq.Length > 0)
+            foreach (var numero in nossoNumeroArray)
             {
-                int valorPosicao = Convert.ToInt32(seq.Substring(0, 1));
-                total += valorPosicao * multiplicador;
-                multiplicador--;
+                total += multiplicador * numero;
 
-                if (multiplicador == 1)
+                if (++multiplicador > 9)
                 {
-                    multiplicador = 9;
+                    multiplicador = 2;
                 }
-
-                seq = seq.Remove(0, 1);
             }
 
-            nresto = total - ((total / 11) * 11);
+            var modulo = total % 11;
 
-            if (nresto == 0 || nresto == 1)
-                ndig = 0;
-            else if (nresto == 10)
-                ndig = 1;
-            else
-                ndig = (11 - nresto);
+            if (modulo > 1)
+            {
+                digito = 11 - modulo;
+            }
 
-            return ndig;
+            return digito;
         }
 
         private static int Mod10Mod11Santander(string seq, int lim)
@@ -1263,7 +1257,7 @@ namespace BoletoNet
                 _detalhe += Utils.FitStringLength(numeroControle, 25, 25, ' ', 0, true, true, false); //alterado por diegodariolli - 15/03/2018 - estava passando vazio impossibilitando controle interno
 
                 //NossoNumero com DV, pegar os 8 primeiros dígitos, da direita para esquerda ==> 063 - 070
-                string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12), 9);//13
+                string nossoNumero = Utils.FormatCode(boleto.NossoNumero, 12) + Mod11Santander(Utils.FormatCode(boleto.NossoNumero, 12));//13
                 _detalhe += Utils.Right(nossoNumero, 8, '0', true);
 
                 //Data do segundo desconto 9(06) ==> 071 - 076


### PR DESCRIPTION
Olá pessoal!

Precisei fazer a integração com o registro de boletos online do Santander, porém o Mod11 do nosso número no BoletoNet não bate com o que é retornado pelo serviço do Santander após o registro.

Segue imagem abaixo com a confirmação do Santander a respeito do registro.

![image](https://user-images.githubusercontent.com/3183034/49964807-8d461d00-ff02-11e8-9e70-1a3bfc142c3f.png)
