### PR TITLE
Opção de endereço sem sacador

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -214,6 +214,14 @@ namespace BoletoNet
             get { return Utils.ToBool(ViewState["9"]); }
             set { ViewState["9"] = value; }
         }
+	
+	[Browsable(true), Description("Mostra o endereço do Cedente sem Avalista")]
+        public bool MostrarEnderecoCedenteSemSacadorAvalista
+        {
+            get { return Utils.ToBool(ViewState["10"]); }
+            set { ViewState["10"] = value; }
+        }
+
 
         #endregion Propriedades
 


### PR DESCRIPTION
Inicio de implementação para possibilitar um layout sem o titulo Sacador Avalista 
Atualmente mostra sempre junto com o endereço e está confundindo alguns homologadores.
Beneficiário Endereço / Sacador Avalista: @AVALISTA