### PR TITLE
Correção para registro tipo 2

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -1238,16 +1238,16 @@ namespace BoletoNet
                 }
 
                 //Data limite para concessão de Desconto 2 ==> 322 a 327
-                _detalhe += new string(' ', 6);
+                _detalhe += new string('000000', 6);
 
                 //Valor do Desconto - 328 a 340
-                _detalhe += new string(' ', 13);
+                _detalhe += new string('0000000000000', 13);
 
                 //Data limite para concessão de Desconto 3 - 341 a 346
-                _detalhe += new string(' ', 6);
+                _detalhe += new string('000000', 6);
 
                 //Valor do Desconto - 347 a 359
-                _detalhe += new string(' ', 13);
+                _detalhe += new string('0000000000000', 13);
 
                 //Reserva - 360 a 366
                 _detalhe += new string(' ', 7);


### PR DESCRIPTION
Nos registros tipo 2, os campos Data de Desconto 2 (posicao 322 a 327), Valor de Desconto 2 (posicao 328 a 340), Data de Desconto 3 (posicao 341 a 346 ) e Valor de Desconto 3 (posicao 347 a 359) devem ser preenchidos com 0