### PR TITLE
Alteração registro 2 itaú

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ src/.vs/config/applicationhost.config
 src/.vs/Boleto.Net.sqlite
 src/.vs/
 /wiki/specs/santander/Santander-CNAB400-2012-02-01-v1.1-Padrao-356-2.pdf
+*.config
+src/.vs/config/applicationhost.config

--- a/src/Boleto.Net.Arquivo/NBoleto.cs
+++ b/src/Boleto.Net.Arquivo/NBoleto.cs
@@ -44,7 +44,10 @@ namespace BoletoNet.Arquivo
             StringBuilder html = new StringBuilder();
             foreach (BoletoBancario o in boletos)
             {
-                html.Append(o.MontaHtml());
+                string logoPath = Application.StartupPath + @"\logoBoleto.jpg";
+                if (!File.Exists(logoPath))
+                    logoPath = "";
+                html.Append(o.MontaHtml(null,logoPath));
                 html.Append("</br></br></br></br></br></br></br></br></br></br>");
             }
 
@@ -471,9 +474,17 @@ namespace BoletoNet.Arquivo
 
                 bb = new BoletoBancario();
                 bb.CodigoBanco = _codigoBanco;
-
+                bb.MostrarEnderecoCedente = true;            
+                //bb.ExibirDemonstrativo = true;
+           
                 DateTime vencimento = DateTime.Now.AddDays(10);
                 Cedente c = new Cedente("00.000.000/0000-00", "Empresa de Atacado", "1234", "5", "12345678", "9");
+                c.Endereco = new Endereco();
+                c.Endereco.End = "Rua teste";
+                c.Endereco.Bairro = "Jd. teste";
+                c.Endereco.CEP = "13211-478";
+                c.Endereco.Cidade = "Cidade Teste";
+                c.Endereco.UF = "SP";
 
                 c.Codigo = "00000000504";
                 Boleto b = new Boleto(vencimento, 45.50m, "11", "12345678901", c);                
@@ -496,7 +507,13 @@ namespace BoletoNet.Arquivo
                 item = new Instrucao_BancoBrasil(81, 15);
                 b.Instrucoes.Add(item);
 
+                ////DEMONSTRATIVO
+                //DemonstrativoValoresBoleto.GrupoDemonstrativo d = new DemonstrativoValoresBoleto.GrupoDemonstrativo();
+                //d.Descricao = "Demonstrativo teste";
+                //b.Demonstrativos.Add(d);
+
                 b.NumeroDocumento = "12345678901";
+                b.LocalPagamento = "Pagável em qualquer banco.";
 
                 bb.Boleto = b;
                 bb.Boleto.Valida();

--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -1490,7 +1490,9 @@ namespace BoletoNet
                     case TipoArquivo.CNAB240:
                         throw new Exception("Mensagem Variavel nao existe para o tipo CNAB 240.");
                     case TipoArquivo.CNAB400:
-                        _detalhe = GerarMensagemVariavelRemessaCNAB400(boleto, ref numeroRegistro, tipoArquivo);
+                        //Comentado por diego.dariolli pois o registro tipo 2 do itaú é somente referente à multa
+                        //_detalhe = GerarMensagemVariavelRemessaCNAB400(boleto, ref numeroRegistro, tipoArquivo);
+                        _detalhe = string.Empty;
                         break;
                     case TipoArquivo.Outro:
                         throw new Exception("Tipo de arquivo inexistente.");

--- a/src/Boleto.Net/Properties/AssemblyInfo.cs
+++ b/src/Boleto.Net/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Web.UI;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the "*" as shown below:
-[assembly: AssemblyVersion("2.0.1.1")]
-[assembly: AssemblyFileVersion("2.0.1.1")]
+[assembly: AssemblyVersion("2.0.1.2")]
+[assembly: AssemblyFileVersion("2.0.1.2")]
 
 [assembly: TagPrefix("BoletoNet", "bn")]


### PR DESCRIPTION
Foi comentada a linha que chama o método GerarMensagemVariavelRemessaCNAB400 do banco itaú (registro tipo 2) pois esse método gera registros de instrução incompatíveis com o manual, onde é mencionado somente dados de multa