### PR TITLE
Campos numéricos segmento R Caixa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ src/.vs/
 /wiki/specs/santander/Santander-CNAB400-2012-02-01-v1.1-Padrao-356-2.pdf
 *.config
 src/.vs/config/applicationhost.config
+src/Boleto.Net/Properties/AssemblyInfo.cs

--- a/src/Boleto.Net/Banco/Banco_Caixa.cs
+++ b/src/Boleto.Net/Banco/Banco_Caixa.cs
@@ -974,10 +974,10 @@ namespace BoletoNet
                 header += "R";                                                                          // Cód. Segmento do Registro Detalhe
                 header += " ";                                                                          // Uso Exclusivo FEBRABAN/CNAB
                 header += "01";                                                                         // Código de Movimento Remessa
-                header += Utils.FormatCode("", " ", 48);                                                // Uso Exclusivo FEBRABAN/CNAB 
+                header += Utils.FormatCode("", "0", 48);                                                // Desconto 2 e Desconto 3 
                 header += "1";                                          // Código da Multa '1' = Valor Fixo,'2' = Percentual,'0' = Sem Multa 
                 header += boleto.DataMulta.ToString("ddMMyyyy");                                        // Data da Multa 
-                header += Utils.FormatCode(boleto.ValorMulta.ToString(CultureInfo.InvariantCulture).Replace(",", "").Replace(".", ""), "0", 13); // Valor/Percentual a Ser Aplicado
+                header += Utils.FormatCode(boleto.ValorMulta.ToString(CultureInfo.InvariantCulture).Replace(",", "").Replace(".", ""), "0", 15); // Valor/Percentual a Ser Aplicado
                 header += Utils.FormatCode("", " ", 10);                                                // Informação ao Sacado
                 header += Utils.FormatCode("", " ", 40);                                                // Mensagem 3
                 header += Utils.FormatCode("", " ", 40);                                                // Mensagem 4

--- a/src/Boleto.Net/Properties/AssemblyInfo.cs
+++ b/src/Boleto.Net/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Web.UI;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the "*" as shown below:
-[assembly: AssemblyVersion("2.0.1.2")]
-[assembly: AssemblyFileVersion("2.0.1.2")]
+[assembly: AssemblyVersion("2.0.1.3")]
+[assembly: AssemblyFileVersion("2.0.1.3")]
 
 [assembly: TagPrefix("BoletoNet", "bn")]


### PR DESCRIPTION
Foram alterados campos no segmento R da Caixa, para colocar valor "0" ao invés de vazio, conforme manual do banco.