### PR TITLE
Correção para linha digitável do Unicred

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Unicred.cs
+++ b/src/Boleto.Net/Banco/Banco_Unicred.cs
@@ -121,12 +121,20 @@ namespace BoletoNet
             int d2 = Mod10Unicred(campo2);
             campo2 = FormataCampoLD(campo2) + d2.ToString();
 
-            string campo3 = boleto.CodigoBarra.Codigo.Substring(34, 10);
+            string NossoNumLinhaDigitavel = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero, false));
+            string campo3 = NossoNumLinhaDigitavel.Substring(NossoNumLinhaDigitavel.Length-10, 10);
+            //A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV
+            //string campo3 = boleto.CodigoBarra.Codigo.Substring(34, 10);
             int d3 = Mod10Unicred(campo3);
             campo3 = FormataCampoLD(campo3) + d3.ToString();
 
-            string campo4 = boleto.CodigoBarra.Codigo.Substring(4, 1);
-
+            string cmp_livre = Utils.FormatCode(boleto.Cedente.ContaBancaria.Agencia, 4) +
+                                    Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 10) +
+                                    Utils.FormatCode(NossoNumLinhaDigitavel, 11);
+            string campo4 = DigUnicred(cmp_livre).ToString();
+            //A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV
+            //string campo4 = boleto.CodigoBarra.Codigo.Substring(4, 1);
+            
             string campo5 = boleto.CodigoBarra.Codigo.Substring(5, 14);
 
             boleto.CodigoBarra.LinhaDigitavel = campo1 + "  " + campo2 + "  " + campo3 + "  " + campo4 + "  " + campo5;


### PR DESCRIPTION
A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV

Mais uma correção para a saga Unicred