### PR TITLE
Sacador/Avalista Itau

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,3 @@ Install-Package Boleto.Net
 
 Para informações sobre o projeto e bancos implementados, consulte o nosso [Wiki](https://github.com/BoletoNet/boletonet/wiki).
 
-
-


### PR DESCRIPTION
No campo sacador/avalista estava sendo passado o nome do sacado e da um problema ao protestar o título