### PR TITLE
Testes unitários corrigidos, data dos testes estava como 2012 e isto …

### DIFF
--- a/src/Boleto.Net.MVC/Boleto.Net.MVC.csproj
+++ b/src/Boleto.Net.MVC/Boleto.Net.MVC.csproj
@@ -30,6 +30,8 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <RestorePackages>true</RestorePackages>
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,6 +57,13 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -62,6 +71,7 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -78,19 +88,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.4.5.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest">
-    </Reference>
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.20710.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>

--- a/src/Boleto.Net.MVC/packages.config
+++ b/src/Boleto.Net.MVC/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.AspNet.WebPages.WebData" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Ajax" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" requireReinstallation="True" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.5.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net45" />

--- a/src/Boleto.Net.Testes/BancoBradescoTeste.cs
+++ b/src/Boleto.Net.Testes/BancoBradescoTeste.cs
@@ -65,7 +65,7 @@ namespace BoletoNet.Testes
 
         private BoletoBancario GerarBoletoCarteira09()
         {
-            DateTime vencimento = new DateTime(2012, 6, 8);
+            DateTime vencimento = new DateTime(2020, 6, 8);
 
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0539", "8", "0032463", "9");
 
@@ -84,7 +84,7 @@ namespace BoletoNet.Testes
 
         private BoletoBancario GerarBoletoComValorCobradoCarteira09()
         {
-            var vencimento = new DateTime(2012, 6, 8);
+            var vencimento = new DateTime(2020, 6, 8);
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0539", "8", "0032463", "9");
 
             var boleto = new Boleto(vencimento, 5000, "09", "18194", cedente);
@@ -117,7 +117,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "23790.53909 90000.001819 94003.246306 3 53580000762000";
+            string linhaDigitavelValida = "23790.53909 90000.001819 94003.246306 8 82800000762000";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -129,7 +129,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            var linhaDigitavelValida = "23790.53909 90000.001819 94003.246306 1 53580000510000";
+            var linhaDigitavelValida = "23790.53909 90000.001819 94003.246306 5 82800000510000";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -141,7 +141,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarraValida = "23793535800007620000539090000001819400324630";
+            string codigoBarraValida = "23798828000007620000539090000001819400324630";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }
@@ -153,7 +153,7 @@ namespace BoletoNet.Testes
 
             boletoBancario.Boleto.Valida();
 
-            var codigoBarraValida = "23791535800005100000539090000001819400324630";
+            var codigoBarraValida = "23795828000005100000539090000001819400324630";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }

--- a/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17019Teste.cs
+++ b/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17019Teste.cs
@@ -11,7 +11,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
         private BoletoBancario GerarBoletoCarteira17019()
         {
-            DateTime vencimento = new DateTime(2012, 6, 14);
+            DateTime vencimento = new DateTime(2020, 6, 14);
 
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0131", "7", "00059127", "0");
 
@@ -79,7 +79,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 9 53640000170000";
+            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 3 82860000170000";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -93,7 +93,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarraValida = "00199536400001700000000002379661000001820417";
+            string codigoBarraValida = "00193828600001700000000002379661000001820417";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }

--- a/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17027Teste.cs
+++ b/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17027Teste.cs
@@ -11,7 +11,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
         private BoletoBancario GerarBoletoCarteira17027()
         {
-            DateTime vencimento = new DateTime(2012, 6, 14);
+            DateTime vencimento = new DateTime(2020, 6, 14);
 
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0131", "7", "00059127", "0");
 
@@ -79,7 +79,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 9 53640000170000";
+            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 3 82860000170000";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -93,7 +93,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarraValida = "00199536400001700000000002379661000001820417";
+            string codigoBarraValida = "00193828600001700000000002379661000001820417";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }

--- a/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17035Teste.cs
+++ b/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17035Teste.cs
@@ -11,7 +11,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
         private BoletoBancario GerarBoletoCarteira17035()
         {
-            DateTime vencimento = new DateTime(2012, 6, 14);
+            DateTime vencimento = new DateTime(2020, 6, 14);
 
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0131", "7", "00059127", "0");
 
@@ -79,7 +79,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 9 53640000170000";
+            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 3 82860000170000";
 
             Assert.AreEqual(linhaDigitavelValida, boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, "Linha digitável inválida");
         }
@@ -93,7 +93,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarraValida = "00199536400001700000000002379661000001820417";
+            string codigoBarraValida = "00193828600001700000000002379661000001820417";
 
             Assert.AreEqual(codigoBarraValida, boletoBancario.Boleto.CodigoBarra.Codigo, "Código de Barra inválido");
         }

--- a/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17051Teste.cs
+++ b/src/Boleto.Net.Testes/BancoBrasil/BancoBrasil17051Teste.cs
@@ -11,7 +11,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
         private BoletoBancario GerarBoletoCarteira17051()
         {
-            DateTime vencimento = new DateTime(2012, 6, 14);
+            DateTime vencimento = new DateTime(2020, 6, 14);
 
             var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "0131", "7", "00059127", "0");
 
@@ -79,7 +79,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 9 53640000170000";
+            string linhaDigitavelValida = "00190.00009 02379.661008 00018.204172 3 82860000170000";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.LinhaDigitavel, linhaDigitavelValida, "Linha digitável inválida");
         }
@@ -93,7 +93,7 @@ namespace Boleto.Net.Testes.BancoBrasil
 
             boletoBancario.Boleto.Valida();
 
-            string codigoBarraValida = "00199536400001700000000002379661000001820417";
+            string codigoBarraValida = "00193828600001700000000002379661000001820417";
 
             Assert.AreEqual(boletoBancario.Boleto.CodigoBarra.Codigo, codigoBarraValida, "Código de Barra inválido");
         }


### PR DESCRIPTION
…quebrava as validações de range permitido para data.