### PR TITLE
Update Banco_Sicoob.cs

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Sicoob.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicoob.cs
@@ -682,7 +682,7 @@ namespace BoletoNet
 
                 detalhe += Utils.FormatCode(vInstrucao1, 2);  //Posição 222 a 223  - Código do protesto
                 detalhe += Utils.FormatCode("0", 1);     //Posição 224  - Código para Baixa/Devolução: "0"
-                detalhe += Utils.FormatCode(" ", 3);     //Posição 225 A 227  - Número de Dias para Baixa/Devolução: Brancos
+		detalhe += "   ";//detalhe += Utils.FormatCode(" ", 3); Posição 225 A 227  - Número de Dias para Baixa/Devolução: Brancos
                 detalhe += Utils.FormatCode(boleto.Moeda.ToString(), "0", 2, true); //Posição 228 A 229  - Código da Moeda
                 detalhe += Utils.FormatCode("", "0", 10, true); //Posição 230 A 239    -  Nº do Contrato da Operação de Créd.: "0000000000"
                 detalhe += " ";


### PR DESCRIPTION
Linha 685 não aplica os três espaços em branco corretamente. Estava sendo aplicado '00 ' devido a função Utils.FormatCode(). Portanto foi colocado 3 espaços fixos.