### PR TITLE
Ajustes no cálculo do dígito verificador Banco Unicred e Remessa do Banco do Brasil

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Brasil.cs
+++ b/src/Boleto.Net/Banco/Banco_Brasil.cs
@@ -1532,6 +1532,12 @@ namespace BoletoNet
                     _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
                     _segmentoP += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
                 }
+                else if (boleto.PercJurosMora > 0)
+                {
+                    _segmentoP += "2";
+                    _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
+                    _segmentoP += Utils.FitStringLength(boleto.PercJurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
+                }
                 else if (boleto.JurosPermanente)
                 {
                     _segmentoP += "1";

--- a/src/Boleto.Net/Banco/Banco_Unicred.cs
+++ b/src/Boleto.Net/Banco/Banco_Unicred.cs
@@ -93,7 +93,7 @@ namespace BoletoNet
 
             try
             {
-                boleto.NossoNumero = string.Format("{0}{1}", nossoNumero, Mod11UniCred(nossoNumero, false));
+                boleto.NossoNumero = string.Format("{0}{1}", nossoNumero, Mod11UniCred(nossoNumero));
             }
             catch (Exception ex)
             {
@@ -120,7 +120,7 @@ namespace BoletoNet
             int d2 = Mod10Unicred(campo2);
             campo2 = FormataCampoLD(campo2) + d2.ToString();
 
-            string NossoNumLinhaDigitavel = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero, false));
+            string NossoNumLinhaDigitavel = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero));
             string campo3 = NossoNumLinhaDigitavel.Substring(NossoNumLinhaDigitavel.Length - 10, 10);
             //A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV
             //string campo3 = boleto.CodigoBarra.Codigo.Substring(34, 10);
@@ -152,7 +152,7 @@ namespace BoletoNet
             string valorBoleto = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
-            var nossoNumero = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero, false));
+            var nossoNumero = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero));
             string cmp_livre = Utils.FormatCode(boleto.Cedente.ContaBancaria.Agencia, 4) +
                                Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta + boleto.Cedente.ContaBancaria.DigitoConta, 10) +
                                Utils.FormatCode(nossoNumero, 11);
@@ -285,7 +285,7 @@ namespace BoletoNet
                 _segmentoP += "0"; //Filler 37 37 1 
                 //_segmentoP += Utils.FitStringLength(boleto.NossoNumero, 11, 11, ' ', 0, true, true, false); //Identificação do Título no Banco 38 48 11
                 _segmentoP += Utils.FitStringLength(boleto.NossoNumero, 10, 10, ' ', 0, true, true, false);
-                _segmentoP += Utils.FitStringLength(Mod11UniCred(boleto.NossoNumero.Substring(0, 10), false).ToString(), 1, 1, ' ', 0, true, true, false);
+                _segmentoP += Utils.FitStringLength(Mod11UniCred(boleto.NossoNumero.Substring(0, 10)).ToString(), 1, 1, ' ', 0, true, true, false);
                 _segmentoP += new string(' ', 8);
                 _segmentoP += Utils.FitStringLength(boleto.Carteira, 2, 2, ' ', 0, true, true, false);
                 _segmentoP += new string(' ', 4);
@@ -521,7 +521,7 @@ namespace BoletoNet
             return d1 + d2;
         }
 
-        protected static int Mod11UniCred(string seq, bool ehBarcode)
+        protected static int Mod11UniCred(string seq)
         {
             /* Variaveis
              * -------------
@@ -543,16 +543,10 @@ namespace BoletoNet
             }
 
             d = 11 - (s % 11);
-            if (ehBarcode)
-            {
-                if (d == 0 || d >= 10)
-                    d = 1;
-            }
-            else
-            {
-                if (d == 0 || d >= 10)
-                    d = 0;
-            }
+
+
+            if (d == 0 || d >= 10)
+                d = 0;
 
             return d;
         }
@@ -584,7 +578,7 @@ namespace BoletoNet
 
             d = 11 - (s % 11);
             if (d == 0 || d == 11 || d == 10)
-                d = 0;
+                d = 1;
             return d;
         }
 

--- a/src/Boleto.Net/Banco/Banco_Unicred.cs
+++ b/src/Boleto.Net/Banco/Banco_Unicred.cs
@@ -1,8 +1,7 @@
 using BoletoNet.EDI.Banco;
 using BoletoNet.Excecoes;
+using BoletoNet.Util;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Web.UI;
 
 [assembly: WebResource("BoletoNet.Imagens.136.jpg", "image/jpg")]
@@ -39,15 +38,15 @@ namespace BoletoNet
 
             if (boleto.LocalPagamento == "Ate o vencimento, preferencialmente no ")
                 boleto.LocalPagamento += Nome;
-            else 
+            else
                 boleto.LocalPagamento = "Pagável em qualquer banco mesmo após o vencimento";
 
             //Verifica se data do processamento eh valida
-            if (boleto.DataProcessamento == DateTime.MinValue) 
+            if (boleto.DataProcessamento == DateTime.MinValue)
                 boleto.DataProcessamento = DateTime.Now;
 
             //Verifica se data do documento Ã© valida
-            if (boleto.DataDocumento == DateTime.MinValue) 
+            if (boleto.DataDocumento == DateTime.MinValue)
                 boleto.DataDocumento = DateTime.Now;
 
             string infoFormatoCodigoCedente = "formato AAAAPPCCCCC, onde: AAAA = Numero da agencia, PP = Posto do beneficiario, CCCCC = Codigo do beneficiario";
@@ -94,7 +93,7 @@ namespace BoletoNet
 
             try
             {
-                boleto.NossoNumero = string.Format("{0}-{1}", nossoNumero, Mod11UniCred(nossoNumero, false));
+                boleto.NossoNumero = string.Format("{0}{1}", nossoNumero, Mod11UniCred(nossoNumero, false));
             }
             catch (Exception ex)
             {
@@ -103,7 +102,7 @@ namespace BoletoNet
             }
         }
 
-        
+
 
         public override void FormataNumeroDocumento(Boleto boleto)
         {
@@ -122,19 +121,23 @@ namespace BoletoNet
             campo2 = FormataCampoLD(campo2) + d2.ToString();
 
             string NossoNumLinhaDigitavel = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero, false));
-            string campo3 = NossoNumLinhaDigitavel.Substring(NossoNumLinhaDigitavel.Length-10, 10);
+            string campo3 = NossoNumLinhaDigitavel.Substring(NossoNumLinhaDigitavel.Length - 10, 10);
             //A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV
             //string campo3 = boleto.CodigoBarra.Codigo.Substring(34, 10);
             int d3 = Mod10Unicred(campo3);
             campo3 = FormataCampoLD(campo3) + d3.ToString();
 
-            string cmp_livre = Utils.FormatCode(boleto.Cedente.ContaBancaria.Agencia, 4) +
+            string cmp_livre =      Utils.FormatCode(boleto.Cedente.ContaBancaria.Agencia, 4) +
                                     Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 10) +
                                     Utils.FormatCode(NossoNumLinhaDigitavel, 11);
-            string campo4 = DigUnicred(cmp_livre).ToString();
-            //A linha digitável nao pode usar a regra de cálculo do DV do barcode pois lá o nosso numero usa uma regra diferente para o DV
-            //string campo4 = boleto.CodigoBarra.Codigo.Substring(4, 1);
-            
+
+            string campo4 = DigUnicred(Codigo.ToString() +//Banco
+                                        boleto.CodigoBarra.Moeda.ToString() + //Moeda
+                                        Utils.FormatCode(FatorVencimento(boleto).ToString(), 4) +
+                                        Utils.FormatCode(boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", ""), 10) +
+                                        cmp_livre                                       
+                                       ).ToString();
+
             string campo5 = boleto.CodigoBarra.Codigo.Substring(5, 14);
 
             boleto.CodigoBarra.LinhaDigitavel = campo1 + "  " + campo2 + "  " + campo3 + "  " + campo4 + "  " + campo5;
@@ -151,98 +154,333 @@ namespace BoletoNet
 
             var nossoNumero = string.Format("{0}{1}", boleto.NossoNumero, Mod11UniCred(boleto.NossoNumero, false));
             string cmp_livre = Utils.FormatCode(boleto.Cedente.ContaBancaria.Agencia, 4) +
-                                                Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 10) +
-                                                Utils.FormatCode(nossoNumero, 11);
+                               Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta + boleto.Cedente.ContaBancaria.DigitoConta, 10) +
+                               Utils.FormatCode(nossoNumero, 11);
 
-            string dv_cmpLivre = DigUnicred(cmp_livre).ToString();
+            //string dv_cmpLivre = DigUnicred(cmp_livre).ToString();
 
-            var codigoTemp = GerarCodigoDeBarras(boleto, valorBoleto, cmp_livre, string.Empty);
+            //var codigoTemp = GerarCodigoDeBarras(boleto, valorBoleto, cmp_livre, string.Empty);
 
             boleto.CodigoBarra.CampoLivre = cmp_livre;
             boleto.CodigoBarra.FatorVencimento = FatorVencimento(boleto);
             boleto.CodigoBarra.Moeda = 9;
             boleto.CodigoBarra.ValorDocumento = valorBoleto;
 
-            int _dacBoleto = DigUnicred(codigoTemp);
+            int digitoGeral = DigUnicred(Codigo.ToString() +//Banco
+                                         boleto.CodigoBarra.Moeda.ToString() + //Moeda
+                                         Utils.FormatCode(boleto.CodigoBarra.FatorVencimento.ToString(), 4) +
+                                         Utils.FormatCode(boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", ""), 10) +
+                                         cmp_livre
+                                        ) ;
 
-            if (_dacBoleto == 0 || _dacBoleto > 9)
-                _dacBoleto = 1;
+
+            //int _dacBoleto = DigUnicred(codigoTemp);
+
+            //if (_dacBoleto == 0 || _dacBoleto > 9)
+            //    _dacBoleto = 1;
 
             //Estava gerando com 46 digitos ao invés de 44, então tirei o dv_cmpLivre para corrigir.
             //boleto.CodigoBarra.Codigo = GerarCodigoDeBarras(boleto, valorBoleto, cmp_livre, dv_cmpLivre, _dacBoleto);
-            boleto.CodigoBarra.Codigo = GerarCodigoDeBarras(boleto, valorBoleto, cmp_livre, string.Empty, _dacBoleto);
+
+            boleto.CodigoBarra.Codigo = GerarCodigoDeBarras(boleto, valorBoleto, cmp_livre, digitoGeral);
         }
 
-        private string GerarCodigoDeBarras(Boleto boleto, string valorBoleto, string cmp_livre, string dv_cmpLivre, int? dv_geral = null)
+        private string GerarCodigoDeBarras(Boleto boleto, string valorBoleto, string cmp_livre, int dv_geral)
         {
-            return string.Format("{0}{1}{2}{3}{4}{5}{6}",
+
+            return string.Format("{0}{1}{2}{3}{4}{5}",
                 Utils.FormatCode(Codigo.ToString(), 3),
                 boleto.Moeda,
-                dv_geral.HasValue ? dv_geral.Value.ToString() : string.Empty,
+                dv_geral,
                 FatorVencimento(boleto),
                 valorBoleto,
-                cmp_livre,
-                dv_cmpLivre);
+                cmp_livre);
         }
 
         #region Metodos de Geracao do Arquivo de Remessa
-        public override string GerarDetalheRemessa(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
-        {
-            throw new BoletoNetException("Nao implantado");
-        }
-        public override string GerarHeaderRemessa(string numeroConvenio, Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa, Boleto boletos)
-        {
-            throw new BoletoNetException("Nao implantado");
-        }
-        public string GerarDetalheRemessaCNAB240(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
-        {
-            throw new BoletoNetException("Nao implantado");
-
-        }
-
-        public override string GerarHeaderRemessa(Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa)
-        {
-
-            throw new BoletoNetException("Nao implantado");
-        }
-
         public override string GerarHeaderRemessa(string numeroConvenio, Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa)
-        {
-            throw new BoletoNetException("Nao implantado");
-        }
-
-        private string GerarHeaderLoteRemessaCNAB240(Cedente cedente, int numeroArquivoRemessa)
         {
             try
             {
-                return GerarHeaderRemessaCNAB240(cedente);
+                string _headerLote;
+                _headerLote = "13600000         ";
+                if (cedente.CPFCNPJ.Length <= 11)
+                    _headerLote += "1";
+                else
+                    _headerLote += "2";
+                _headerLote += Utils.FitStringLength(cedente.CPFCNPJ, 14, 14, '0', 0, true, true, true);
+                _headerLote += new string(' ', 20);
+                _headerLote += Utils.FitStringLength(cedente.ContaBancaria.Agencia, 5, 5, '0', 0, true, true, true);
+                _headerLote += Utils.FitStringLength(cedente.ContaBancaria.DigitoAgencia, 1, 1, '0', 0, true, true, true);
+                //_headerLote += Utils.FitStringLength(cedente.ContaBancaria.Conta, 12, 12, '0', 0, true, true, true);
+                _headerLote += Utils.FitStringLength(cedente.Codigo, 14, 14, '0', 0, true, true, true);
+                //_headerLote += " ";
+                _headerLote += Utils.FitStringLength(cedente.Nome, 30, 30, ' ', 0, true, true, false);
+                _headerLote += Utils.FitStringLength("UNICRED", 30, 30, ' ', 0, true, true, false);
+                _headerLote += new string(' ', 10);
+                _headerLote += "1";
+                _headerLote += DateTime.Now.ToString("ddMMyyyy");
+                //_headerLote += "000000";// DateTime.Now.ToString("HHmmss");
+                _headerLote += DateTime.Now.ToString("HHmmss");
+                _headerLote += numeroArquivoRemessa.ToString("000000");
+                _headerLote += "085";
+                _headerLote += "00000";
+                //_headerLote += Utils.FitStringLength(cedente.CodigoTransmissao, 3, 3, '0', 0, true, true, true);
+                _headerLote += "000";
+                
+                _headerLote += new string(' ', 66);
+                return _headerLote;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("Erro ao gerar HEADER DO LOTE do arquivo de remessa.", e);
+                throw new Exception("Erro ao gerar HEADER do arquivo de remessa do CNAB400.", ex);
             }
         }
 
         public override string GerarHeaderLoteRemessa(string numeroConvenio, Cedente cedente, int numeroArquivoRemessa, TipoArquivo tipoArquivo)
         {
-            throw new BoletoNetException("Nao implantado");
+            string _headerLote;
+            _headerLote = "13600011R01  044 ";
+            if (cedente.CPFCNPJ.Length <= 11)
+                _headerLote += "1";
+            else
+                _headerLote += "2";
+            _headerLote += Utils.FitStringLength(cedente.CPFCNPJ, 15, 15, '0', 0, true, true, true);
+            _headerLote += new string(' ', 20);
+            _headerLote += Utils.FitStringLength(cedente.ContaBancaria.Agencia, 5, 5, '0', 0, true, true, true);
+            _headerLote += Utils.FitStringLength(cedente.ContaBancaria.DigitoAgencia, 1, 1, '0', 0, true, true, true);
+            //_headerLote += Utils.FitStringLength(cedente.ContaBancaria.Conta, 12, 12, '0', 0, true, true, true);
+            _headerLote += Utils.FitStringLength(cedente.ContaBancaria.Conta, 13, 13, '0', 0, true, true, true);
+            _headerLote += Utils.FitStringLength(cedente.ContaBancaria.DigitoConta, 1, 1, '0', 0, true, true, true);
+            //_headerLote += " ";
+            _headerLote += Utils.FitStringLength(cedente.Nome, 30, 30, ' ', 0, true, true, false);
+            _headerLote += new string(' ', 40);
+            _headerLote += new string(' ', 40);
+            _headerLote += numeroArquivoRemessa.ToString("00000000");
+            _headerLote += DateTime.Now.ToString("ddMMyyyy");
+            _headerLote += new string(' ', 8);
+            //_headerLote += new string(' ', 33);
+            _headerLote += new string('0', 2);
+            _headerLote += new string(' ', 31);
+            return _headerLote;
         }
 
-        public string GerarHeaderRemessaCNAB240(Cedente cedente)
+        public override string GerarDetalheSegmentoPRemessa(Boleto boleto, int numeroRegistro, string numeroConvenio)
         {
-            throw new BoletoNetException("Nao implantado");
+            try
+            {
+                string _segmentoP;
+                //string _nossoNumero;
+
+                _segmentoP = "136"; //Código do Banco na Compensação 1 3 3
+                _segmentoP += "0001"; //Lote de Serviço 4 7 4
+                _segmentoP += "3"; //Tipo de Registro 8 8 1
+                _segmentoP += Utils.FitStringLength(numeroRegistro.ToString(), 5, 5, '0', 0, true, true, true); //Nº Sequencial do Registro no Lote 9 13 5
+                _segmentoP += "P "; //Cód. Segmento do Registro Detalhe 14 14 1 
+                _segmentoP += ObterCodigoDaOcorrencia(boleto);
+                _segmentoP += Utils.FitStringLength(boleto.Cedente.ContaBancaria.Agencia, 5, 5, '0', 0, true, true, true); //Agência Mantenedora da Conta 18 22 5
+                _segmentoP += Utils.FitStringLength(boleto.Cedente.ContaBancaria.DigitoAgencia, 1, 1, '0', 0, true, true, true); //Dígito Verificador da Agência 23 23 1
+                _segmentoP += Utils.FitStringLength(boleto.Cedente.ContaBancaria.Conta, 12, 12, '0', 0, true, true, true); //Número da Conta Corrente 24 35 12
+                _segmentoP += Utils.FitStringLength(boleto.Cedente.ContaBancaria.DigitoConta, 1, 1, '0', 0, true, true, true); //Dígito Verificador da Conta 36 36 1
+                _segmentoP += "0"; //Filler 37 37 1 
+                //_segmentoP += Utils.FitStringLength(boleto.NossoNumero, 11, 11, ' ', 0, true, true, false); //Identificação do Título no Banco 38 48 11
+                _segmentoP += Utils.FitStringLength(boleto.NossoNumero, 10, 10, ' ', 0, true, true, false);
+                _segmentoP += Utils.FitStringLength(Mod11UniCred(boleto.NossoNumero, false).ToString(), 1, 1, ' ', 0, true, true, false);
+                _segmentoP += new string(' ', 8);
+                _segmentoP += Utils.FitStringLength(boleto.Carteira, 2, 2, ' ', 0, true, true, false);
+                _segmentoP += new string(' ', 4);
+                _segmentoP += Utils.FitStringLength(boleto.NumeroDocumento, 15, 15, ' ', 0, true, true, false);
+                _segmentoP += Utils.FitStringLength(boleto.DataVencimento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
+                _segmentoP += Utils.FitStringLength(boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", ""), 15, 15, '0', 0, true, true, true);
+                //_segmentoP += new string(' ', 8);
+                _segmentoP += new string(' ', 6);
+                _segmentoP += "N";
+                _segmentoP += new string(' ', 1);
+                _segmentoP += "N";
+                _segmentoP += Utils.FitStringLength(boleto.DataDocumento.ToString("ddMMyyyy"), 8, 8, ' ', 0, true, true, false);
+
+                if (boleto.JurosMora > 0)
+                {
+                    _segmentoP += "1";
+                    _segmentoP += "00000000";
+                    _segmentoP += Utils.FitStringLength(boleto.JurosMora.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
+                }
+                else
+                {
+                    _segmentoP += "5";
+                    //_segmentoP += "00000000";
+                    //_segmentoP += "000000000000000";
+                    _segmentoP += new string(' ', 8); //Filler 119 126 8
+                    _segmentoP += new string('0', 15);  //Juros de Mora por Dia/Taxa 127 141 15
+                }
+
+                if (boleto.ValorDesconto > 0)
+                {
+                    _segmentoP += "1";
+                    _segmentoP +=
+                        Utils.FitStringLength(
+                            boleto.DataDesconto == DateTime.MinValue
+                                ? boleto.DataVencimento.ToString("ddMMyyyy")
+                                : boleto.DataDesconto.ToString("ddMMyyyy"), 8, 8, '0', 0, true, true, false);
+                    _segmentoP += Utils.FitStringLength(boleto.ValorDesconto.ApenasNumeros(), 15, 15, '0', 0, true, true, true);
+                }
+                else
+                    _segmentoP += "000000000000000000000000";
+
+                //_segmentoP += "000000000000000";
+                //_segmentoP += "000000000000000";
+                _segmentoP += new string(' ', 15); //Filler 166 180 15 Alfa
+                _segmentoP += new string('0', 15); //Valor do Abatimento 181 195 15 Num
+
+                _segmentoP += Utils.FitStringLength(boleto.NumeroControle ?? boleto.NumeroDocumento, 25, 25, ' ', 0, true, true, false); //alterado por diegodariolli - 15/03/2018 //Identificação do Título na Empresa 196 220 25 - Alfa
+                //_segmentoP += " ";
+                //_segmentoP += "  ";
+                _segmentoP += new string('0', 1); //Código para Protesto 221 221 1 - Num Zeros
+                //_segmentoP += "0";
+                _segmentoP += new string('0', 2); //Número de Dias para Protesto 222 223 2 - Num 
+                //_segmentoP += "   ";
+                _segmentoP += new string(' ', 4); //Filler 224 227 4 - Alfa
+                //_segmentoP += "  ";
+                _segmentoP += "09"; //Código da Moeda 228 229 2 - Num
+                //_segmentoP += "0000000000";
+                _segmentoP += new string('0', 10);//Nº do Contrato da Operação de Créd. 230 239 10 - Num
+                _segmentoP += " "; //Uso Exclusivo FEBRABAN/CNAB 240 240 1 - Alfa
+                _segmentoP = Utils.SubstituiCaracteresEspeciais(_segmentoP.ToUpper());
+                return _segmentoP;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do SEGMENTO P DO DETALHE do arquivo de REMESSA.", ex);
+            }
         }
 
-        public override string GerarTrailerRemessa(int numeroRegistro, TipoArquivo tipoArquivo, Cedente cedente, decimal vltitulostotal)
+        public override string GerarDetalheSegmentoQRemessa(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
         {
-            throw new BoletoNetException("Nao implantado");
-        }
+            try
+            {
+                string _segmentoQ;
 
-        public string GerarTrailerRemessa240(int numeroRegistro)
+                _segmentoQ = "13600013";
+                _segmentoQ += Utils.FitStringLength(numeroRegistro.ToString(), 5, 5, '0', 0, true, true, true);
+                _segmentoQ += "Q ";
+                _segmentoQ += ObterCodigoDaOcorrencia(boleto);
+
+                if (boleto.Sacado.CPFCNPJ.Length <= 11)
+                    _segmentoQ += "1";
+                else
+                    _segmentoQ += "2";
+
+                var enderecoSacadoComNumero = boleto.Sacado.Endereco.End;
+                if (!string.IsNullOrEmpty(boleto.Sacado.Endereco.Numero))
+                {
+                    enderecoSacadoComNumero += ", " + boleto.Sacado.Endereco.Numero;
+                }
+
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.CPFCNPJ, 15, 15, '0', 0, true, true, true);
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.Nome.TrimStart(' '), 40, 40, ' ', 0, true, true, false).ToUpper();
+                _segmentoQ += Utils.FitStringLength(enderecoSacadoComNumero.TrimStart(' '), 40, 40, ' ', 0, true, true, false).ToUpper();
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.Endereco.Bairro.TrimStart(' '), 15, 15, ' ', 0, true, true, false).ToUpper();
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.Endereco.CEP, 8, 8, ' ', 0, true, true, false).ToUpper(); ;
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.Endereco.Cidade.TrimStart(' '), 15, 15, ' ', 0, true, true, false).ToUpper();
+                _segmentoQ += Utils.FitStringLength(boleto.Sacado.Endereco.UF, 2, 2, ' ', 0, true, true, false).ToUpper();
+
+                if (boleto.Avalista != null)
+                {
+                    if (boleto.Avalista.CPFCNPJ.Length <= 11)
+                        _segmentoQ += "1";
+                    else
+                        _segmentoQ += "2";
+                    _segmentoQ += Utils.FitStringLength(boleto.Avalista.CPFCNPJ, 15, 15, '0', 0, true, true, true);
+                    _segmentoQ += Utils.FitStringLength(boleto.Avalista.Nome, 40, 40, '0', 0, true, true, true);
+                }
+                else
+                {
+                    _segmentoQ += "1";
+                    _segmentoQ += new string('0', 15);
+                    _segmentoQ += new string(' ', 40);
+                }
+                //_segmentoQ += "000";
+                //_segmentoQ += new string(' ', 28);
+                _segmentoQ += new string(' ', 31);
+                _segmentoQ = Utils.SubstituiCaracteresEspeciais(_segmentoQ);
+
+                return _segmentoQ;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do SEGMENTO Q DO DETALHE do arquivo de REMESSA.", ex);
+            }
+        }
+        
+        public override string GerarDetalheSegmentoRRemessa(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
         {
-            throw new BoletoNetException("Nao implantado");
+            try
+            {
+                string _segmentoR;
+
+                _segmentoR = "13600013";
+                _segmentoR += Utils.FitStringLength(numeroRegistro.ToString(), 5, 5, '0', 0, true, true, true);
+                _segmentoR += "R ";
+                _segmentoR += ObterCodigoDaOcorrencia(boleto);
+                _segmentoR += new string('0', 44);
+                _segmentoR += " ";
+                _segmentoR += new string('0', 21);
+                _segmentoR += new string(' ', 10);
+
+                for (int i = 0; i < 2; i++)
+                {
+                    if (boleto.Instrucoes.Count > i)
+                        _segmentoR += Utils.FitStringLength(boleto.Instrucoes[i].Descricao, 40, 40, ' ', 0, true, true, false);
+                    else
+                        _segmentoR += new string(' ', 40);
+                }
+
+                _segmentoR += new string(' ', 20);
+                _segmentoR += new string('0', 32);
+                _segmentoR += new string(' ', 9);
+                _segmentoR = Utils.SubstituiCaracteresEspeciais(_segmentoR);
+
+                return _segmentoR;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do SEGMENTO R DO DETALHE do arquivo de REMESSA.", ex);
+            }
         }
 
+        public override string GerarTrailerLoteRemessa(int numeroRegistro)
+        {
+            string _trailer = "";
+            _trailer += "13600015";
+            _trailer += new string(' ', 9);
+            _trailer += numeroRegistro.ToString("000000");
+            _trailer += "000000";
+            _trailer += "00000000000000000";
+            _trailer += "000000";
+            _trailer += "00000000000000000";
+            _trailer += "000000";
+            _trailer += "00000000000000000";
+            _trailer += "000000";
+            _trailer += "00000000000000000";
+            //_trailer += new string(' ', 8);
+            _trailer += new string('0', 8);
+            _trailer += new string(' ', 117);
+            return _trailer;
+
+        }
+        public override string GerarTrailerArquivoRemessa(int numeroRegistro)
+        {
+            string _trailer = "";
+            _trailer += "13699999";
+            _trailer += new string(' ', 9);
+            //_trailer += numeroRegistro.ToString("000000");
+            _trailer += "000001";
+            //_trailer += (numeroRegistro + 4).ToString("000000");
+            _trailer += numeroRegistro.ToString("000000");
+            _trailer += "000000";
+            _trailer += new string(' ', 205);
+            return _trailer;
+        }
         #endregion
 
         public int Mod10Unicred(string seq)
@@ -329,16 +567,15 @@ namespace BoletoNet
               * b - Base
               * r - Resto
               */
-            int[] mult = seq.Length == 25 ? new[] { 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 } :
-                new[] { 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7 };
+            int[] mult =  new[] { 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
 
             int d, s = 0, i = 0;
 
             foreach (char c in seq)
             {
-                if (seq.Length > mult.Length)
+                if (seq.Length != mult.Length)
                 {
-                    throw new BoletoNetException("Tamanho da sequencia maior que o limite");
+                    throw new BoletoNetException("Tamanho da sequencia diferente do limite");
                 }
                 var mul = mult[i];
                 s += (int.Parse(c.ToString()) * mul);
@@ -346,8 +583,8 @@ namespace BoletoNet
             }
 
             d = 11 - (s % 11);
-            if (d == 0 || d == 1|| d == 10)
-                d = 1;
+            if (d == 0 || d == 11 || d == 10)
+                d = 0;
             return d;
         }
 
@@ -356,7 +593,12 @@ namespace BoletoNet
         /// </summary>
         public override bool ValidarRemessa(TipoArquivo tipoArquivo, string numeroConvenio, IBanco banco, Cedente cedente, Boletos boletos, int numeroArquivoRemessa, out string mensagem)
         {
-            throw new BoletoNetException("Nao implantado");
+            bool vRetorno = true;
+            string vMsg = string.Empty;
+            ////IMPLEMENTACAO PENDENTE...
+            mensagem = vMsg;
+            return vRetorno;
+
         }
     }
 }


### PR DESCRIPTION
 -Para o Banco Unicred, foi ajustado o cálculo do dígito verificador do nosso número e também ajustado o digito verificador geral do código de barras e linha digitável
- Para arquivo de Remessa do Banco do Brasil, foi possibilitado enviar o Juros de Mora na forma de Percentual