### PR TITLE
Corrigido rotina para composição do código do cedente.

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Sicredi.cs
+++ b/src/Boleto.Net/Banco/Banco_Sicredi.cs
@@ -65,7 +65,7 @@ namespace BoletoNet
                 (!codigoCedente.StartsWith(boleto.Cedente.ContaBancaria.Agencia) ||
                  !(codigoCedente.EndsWith(conta) || codigoCedente.EndsWith(conta.Substring(0, conta.Length - 1)))))
                 //throw new BoletoNetException("Código do cedente deve estar no " + infoFormatoCodigoCedente);
-                boleto.Cedente.Codigo = string.Format("{0}{1}{2}", boleto.Cedente.ContaBancaria.Agencia, boleto.Cedente.ContaBancaria.OperacaConta, Utils.Right((boleto.Cedente.Codigo + boleto.Cedente.DigitoCedente), 5, '0', true));
+                boleto.Cedente.Codigo = string.Format("{0}{1}{2}", boleto.Cedente.ContaBancaria.Agencia, boleto.Cedente.ContaBancaria.OperacaConta, (boleto.Cedente.Codigo.Length >= 5 ? Utils.Right(boleto.Cedente.Codigo, 5, '0', true) : Utils.Right((boleto.Cedente.Codigo + boleto.Cedente.DigitoCedente), 5, '0', true)));
 
             if (string.IsNullOrEmpty(boleto.Carteira))
                 throw new BoletoNetException("Tipo de carteira é obrigatório. " + ObterInformacoesCarteirasDisponiveis());


### PR DESCRIPTION
Corrigido rotina para composição do código do cedente, para não sofrer alteração quando este já conter 5 dígitos.

@brunoguelere , precisamos ter cuidado ao adicionar um campo ao código, que não é utilizado em mais nenhuma parte do mesmo código. Neste caso, vc adicionou o DigitoCedente à linha 68, e em nenhuma parte do mesmo código ele é preenchido ou referenciado, ou seja, quem não utiliza este campo preenchendo ele em seus respectivos sistemas, fica com erro! 