### PR TITLE
bugfix: Exibir corretamente valor do campo outros acrescimos

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -895,7 +895,8 @@ namespace BoletoNet
                 .Replace(
                     "@VALORCOBRADO",
                     (Boleto.ValorCobrado == 0 ? "" : Boleto.ValorCobrado.ToString("C", CultureInfo.GetCultureInfo("PT-BR"))))
-                .Replace("@OUTROSACRESCIMOS", "")
+                .Replace("@OUTROSACRESCIMOS",
+                    (Boleto.OutrosAcrescimos == 0 ? "" : Boleto.OutrosAcrescimos.ToString("C", CultureInfo.GetCultureInfo("PT-BR"))))
                 .Replace("@OUTRASDEDUCOES", "")
                 .Replace(
                     "@DESCONTOS",


### PR DESCRIPTION
Ao preencher a variável OutrosAcrescimos nada acontecia.
Alterei esse trecho de código e tudo se resolveu.

![image](https://user-images.githubusercontent.com/28662273/142044672-5ef2a848-f30e-4ab2-8f57-71279711ca46.png)

Aparentemente os testes também.
Favor verificar se é uma correção valida para próxima release. o;)