### PR TITLE
Valor CodBarras incorreto ao utilizar o campo ValorCobrado

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -109,19 +109,11 @@ namespace BoletoNet
 
             string Grupo5 = string.Empty;
 
-            //string FFFF = boleto.CodigoBarra.Codigo.Substring(5, 4);//FatorVencimento(boleto).ToString() ;
             string FFFF = FatorVencimento(boleto).ToString();
-
-            //if (boleto.Carteira == "06" && !Utils.DataValida(boleto.DataVencimento))
-            //    FFFF = "0000";
-
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            string VVVVVVVVVV = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            
+            string VVVVVVVVVV = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             VVVVVVVVVV = Utils.FormatCode(VVVVVVVVVV, 10);
-
-            //if (Utils.ToInt64(VVVVVVVVVV) == 0)
-            //    VVVVVVVVVV = "000";
-
+            
             Grupo5 = string.Format("{0}{1}", FFFF, VVVVVVVVVV);
 
             #endregion Campo 5
@@ -148,8 +140,7 @@ namespace BoletoNet
         /// 
         public override void FormataCodigoBarra(Boleto boleto)
         {
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            var valorBoleto = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            var valorBoleto = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
             if (boleto.Carteira == "02" || boleto.Carteira == "03" || boleto.Carteira == "04" || boleto.Carteira == "09" || boleto.Carteira == "19" || boleto.Carteira == "26") // Com registro

--- a/src/Boleto.Net/Banco/Banco_Caixa.cs
+++ b/src/Boleto.Net/Banco/Banco_Caixa.cs
@@ -53,8 +53,7 @@ namespace BoletoNet
             long fatorVencimento = FatorVencimento(boleto);
 
             // Posição 10 - 19     
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            string valorDocumento = valor.ToString("f").Replace(",", "").Replace(".", "");
+            string valorDocumento = boleto.ValorCodBarra.ToString("f").Replace(",", "").Replace(".", "");
             valorDocumento = Utils.FormatCode(valorDocumento, 10);
 
 
@@ -328,7 +327,7 @@ namespace BoletoNet
 
                 long FFFF = FatorVencimento(boleto);
 
-                string VVVVVVVVVV = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                string VVVVVVVVVV = boleto.ValorCodBarra.ToString("f").Replace(",", "").Replace(".", "");
                 VVVVVVVVVV = Utils.FormatCode(VVVVVVVVVV, 10);
 
                 if (Utils.ToInt64(VVVVVVVVVV) == 0)

--- a/src/Boleto.Net/Banco/Banco_Itau.cs
+++ b/src/Boleto.Net/Banco/Banco_Itau.cs
@@ -149,7 +149,7 @@ namespace BoletoNet
                 // Código de Barras
                 //banco & moeda & fator & valor & carteira & nossonumero & dac_nossonumero & agencia & conta & dac_conta & "000"
 
-                string valorBoleto = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                string valorBoleto = boleto.ValorCodBarra.ToString("f").Replace(",", "").Replace(".", "");
                 valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
                 string numeroDocumento = Utils.FormatCode(boleto.NumeroDocumento.ToString(), 7);
@@ -160,8 +160,8 @@ namespace BoletoNet
                     boleto.CodigoBarra.Codigo =
                         string.Format("{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}000", Codigo, boleto.Moeda,
                                       FatorVencimento(boleto), valorBoleto, boleto.Carteira,
-                                      boleto.NossoNumero, _dacNossoNumero, boleto.Cedente.ContaBancaria.Agencia,//Flavio(fhlviana@hotmail.com) => Cedente.ContaBancaria.Agencia --> boleto.Cedente.ContaBancaria.Agencia
-                                      Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 5), boleto.Cedente.ContaBancaria.DigitoConta);//Flavio(fhlviana@hotmail.com) => Cedente.ContaBancaria.DigitoConta --> boleto.Cedente.ContaBancaria.DigitoConta
+                                      boleto.NossoNumero, _dacNossoNumero, boleto.Cedente.ContaBancaria.Agencia,
+                                      Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 5), boleto.Cedente.ContaBancaria.DigitoConta);
                 }
                 else if (boleto.Carteira == "198" || boleto.Carteira == "107"
                          || boleto.Carteira == "122" || boleto.Carteira == "142"
@@ -203,7 +203,8 @@ namespace BoletoNet
                 string K = string.Format(" {0} ", _dacBoleto);
 
                 string UUUU = FatorVencimento(boleto).ToString();
-                string VVVVVVVVVV = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+
+                string VVVVVVVVVV = boleto.ValorCodBarra.ToString("f").Replace(",", "").Replace(".", "");
 
                 string C1 = string.Empty;
                 string C2 = string.Empty;

--- a/src/Boleto.Net/Banco/Banco_Semear.cs
+++ b/src/Boleto.Net/Banco/Banco_Semear.cs
@@ -100,8 +100,7 @@ namespace BoletoNet
 
             string fatorVencimento = FatorVencimento(boleto).ToString();
 
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            string valorFormatado = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            string valorFormatado = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             valorFormatado = Utils.FormatCode(valorFormatado, 10);
 
             Grupo5 = string.Format("{0}{1}", fatorVencimento, valorFormatado);
@@ -129,8 +128,7 @@ namespace BoletoNet
         /// 
         public override void FormataCodigoBarra(Boleto boleto)
         {
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            var valorBoleto = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            var valorBoleto = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
             if (boleto.Carteira == "02") // Com registro

--- a/src/Boleto.Net/Banco/Banco_Uniprime.cs
+++ b/src/Boleto.Net/Banco/Banco_Uniprime.cs
@@ -119,17 +119,10 @@ namespace BoletoNet
             string Grupo5 = string.Empty;
 
             string FFFF = FatorVencimento2000(boleto).ToString();
-
-            //if (boleto.Carteira == "06" && !Utils.DataValida(boleto.DataVencimento))
-            //    FFFF = "0000";
-
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            string VVVVVVVVVV = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            
+            string VVVVVVVVVV = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             VVVVVVVVVV = Utils.FormatCode(VVVVVVVVVV, 10);
-
-            //if (Utils.ToInt64(VVVVVVVVVV) == 0)
-            //    VVVVVVVVVV = "000";
-
+            
             Grupo5 = string.Format("{0}{1}", FFFF, VVVVVVVVVV);
 
             #endregion Campo 5
@@ -156,8 +149,7 @@ namespace BoletoNet
         /// 
         public override void FormataCodigoBarra(Boleto boleto)
         {
-            var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;
-            var valorBoleto = valor.ToString("N2").Replace(",", "").Replace(".", "");
+            var valorBoleto = boleto.ValorCodBarra.ToString("N2").Replace(",", "").Replace(".", "");
             valorBoleto = Utils.FormatCode(valorBoleto, 10);
 
             if (boleto.Carteira == "02" || boleto.Carteira == "03" || boleto.Carteira == "04" || boleto.Carteira == "09" || boleto.Carteira == "19" || boleto.Carteira == "26") // Com registro

--- a/src/Boleto.Net/Boleto/Boleto.cs
+++ b/src/Boleto.Net/Boleto/Boleto.cs
@@ -202,6 +202,19 @@ namespace BoletoNet
 			set { this._valorCobrado = value; }
 		}
 
+
+		/// <summary> 
+		/// Retorna o valor impresso no cod. de barras 
+		/// </summary>
+		/// <remarks>
+		/// Se o valor ValorCobrado estiver preenchido retorna o valor cobrado,
+        /// caso contrário retorna o ValorBoleto.
+		/// </remarks>
+		public decimal ValorCodBarra
+        {
+            get { return (this.ValorCobrado > 0) ? this.ValorCobrado : this.ValorBoleto; }
+        }
+
 		/// <summary> 
 		/// Retorna o campo para a 1 linha da instrucao.
 		/// </summary>

--- a/src/Boleto.Net/Boleto/Boleto.cs
+++ b/src/Boleto.Net/Boleto/Boleto.cs
@@ -204,15 +204,15 @@ namespace BoletoNet
 
 
 		/// <summary> 
-		/// Retorna o valor impresso no cod. de barras 
+		/// Retorna o valor utilizado no cod. de barras 
 		/// </summary>
 		/// <remarks>
-		/// Se o valor ValorCobrado estiver preenchido retorna o valor cobrado,
+        /// Se o valor ValorCobrado estiver preenchido retorna o ValorCobrado,
         /// caso contrário retorna o ValorBoleto.
 		/// </remarks>
 		public decimal ValorCodBarra
         {
-            get { return (this.ValorCobrado > 0) ? this.ValorCobrado : this.ValorBoleto; }
+			get { return (this.ValorCobrado > 0) ? this.ValorCobrado : this.ValorBoleto; }
         }
 
 		/// <summary> 


### PR DESCRIPTION
O Problema:
Ao utilizar campos de descontos e acrescimos e chegar no ValorCobrado o sistema sempre acata o ValorBoleto 

A solução: 
Criar uma condição verificando se o valor ValorCobrado estiver preenchido utilizamos o ValorCobrado,
caso contrário utilizamos o ValorBoleto (retornado atualmente)

Exemplo:
![image](https://user-images.githubusercontent.com/28662273/143664662-d8612de9-fed3-4727-a74e-3825738c2df7.png)

Isso já era realizado para alguns bancos porém com a seguinte regra:
`var valor = boleto.ValorCobrado > boleto.ValorBoleto ? boleto.ValorCobrado : boleto.ValorBoleto;`
porém não concordo com essa regra, pois se o valor do documento for 1000,00 o valor do desconto/Abatimento for 200,00 logo o valor cobrado será de 800,00 e o valor do cod. de barras ainda ficaria incorreto.
Por esse motivo unifiquei essa regra e criei uma propriedade ReadOnly na classe principal simplificando a regra.
`public decimal ValorCodBarra
        {
			get { return (this.ValorCobrado > 0) ? this.ValorCobrado : this.ValorBoleto; }
        }`
Assim o proximo "Jumi da India" que nem eu só de bater o olho saberá a regra e em quais bancos esta implementada.
