### PR TITLE
Novo padrão Código do Cedente/Beneficiário com 7 dígitos.

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Caixa.cs
+++ b/src/Boleto.Net/Banco/Banco_Caixa.cs
@@ -395,7 +395,7 @@ namespace BoletoNet
 
                 if (!boleto.Cedente.Codigo.Equals("0"))
                 {
-                    string codigoCedente = Utils.FormatCode(boleto.Cedente.Codigo, 6);
+                    string codigoCedente = Utils.FormatCode(boleto.Cedente.Codigo, 7);
                     string dvCodigoCedente = Mod10(codigoCedente).ToString(); //Base9 
 
                     if (boleto.Cedente.DigitoCedente.Equals(-1))
@@ -413,8 +413,8 @@ namespace BoletoNet
             if (boleto.DataDocumento == DateTime.MinValue)
                 boleto.DataDocumento = DateTime.Now;
 
-            if (boleto.Cedente.Codigo.Length > 6)
-                throw new Exception("O código do cedente deve conter apenas 6 dígitos");
+            if (boleto.Cedente.Codigo.Length > 7)
+                throw new Exception("O código do cedente deve conter apenas 7 dígitos");
 
             //Atribui o nome do banco ao local de pagamento
             //Suélton 23/03/18 - Na homolagação do boleto junto a Caixa solicitaram que o texto do local de pagamento fosse esse

--- a/src/Boleto.Net/Banco/Banco_Caixa.cs
+++ b/src/Boleto.Net/Banco/Banco_Caixa.cs
@@ -414,7 +414,7 @@ namespace BoletoNet
                 boleto.DataDocumento = DateTime.Now;
 
             if (boleto.Cedente.Codigo.Length > 7)
-                throw new Exception("O código do cedente deve conter apenas 7 dígitos");
+                throw new Exception("O código do cedente deve conter 6 ou 7 dígitos");
 
             //Atribui o nome do banco ao local de pagamento
             //Suélton 23/03/18 - Na homolagação do boleto junto a Caixa solicitaram que o texto do local de pagamento fosse esse


### PR DESCRIPTION
Segundo o manual, agora o Código do Cedente/Beneficiário pode conter até 7 dígitos. 

![image](https://user-images.githubusercontent.com/52205173/171016669-3dd48f23-09e5-4635-8c4d-289197f9e9aa.png)

Manual:
[Manual_de_Leiaute_de_Arquivo_Eletronico_CNAB_240.pdf](https://github.com/BoletoNet/boletonet/files/8799217/Manual_de_Leiaute_de_Arquivo_Eletronico_CNAB_240.pdf)
