### PR TITLE
Adicionando a palavra 'Juros' no boleto da Caixa

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -840,7 +840,10 @@ namespace BoletoNet
                 html.Append(GeraHtmlReciboCedente());
             }
 
-            //html.Append(!FormatoCarne ? !FormatoPropaganda ? GeraHtmlReciboCedente() : GeraHtmlPropaganda(GeraHtmlReciboCedente()) : GeraHtmlCarne(GeraHtmlReciboCedente()));
+ 	    if (Boleto.Banco.Codigo == 104)
+                html.Replace("Mora / Multa", "Mora / Multa / Juros");
+
+	    //html.Append(!FormatoCarne ? !FormatoPropaganda ? GeraHtmlReciboCedente() : GeraHtmlPropaganda(GeraHtmlReciboCedente()) : GeraHtmlCarne(GeraHtmlReciboCedente()));
 
             string dataVencimento = Boleto.DataVencimento.ToString("dd/MM/yyyy");
 


### PR DESCRIPTION
No boleto da CEF é necessário apresentar a palavra `Juros` junto com `Mora / Multa`.

![image](https://user-images.githubusercontent.com/52205173/173138137-54c58485-946a-4303-a793-ff09e6280d8e.png)
