### PR TITLE
Acerto erro numeroRegistros Instruções Santander

### DIFF
--- a/src/Boleto.Net.Testes/BancoSantanderTeste.cs
+++ b/src/Boleto.Net.Testes/BancoSantanderTeste.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace BoletoNet.Testes
@@ -12,7 +17,7 @@ namespace BoletoNet.Testes
         {
             DateTime vencimento = new DateTime(2022, 12, 4);
 
-            var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "3265", "3309894", "4");
+            var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "32651", "3309894123", "4");
 
             cedente.Codigo = "3309894";
 
@@ -131,6 +136,75 @@ namespace BoletoNet.Testes
             Assert.AreEqual(dv, 8, "Linha digitável inválida");
         }
 
+        #endregion
+
+        #region Remessa
+
+        private BoletoBancario GerarBoletoRemessa()
+        {
+            DateTime vencimento = new DateTime(2022, 12, 4);
+
+            var cedente = new Cedente("00.000.000/0000-00", "Empresa Teste", "32651", "3309894123", "4");
+            cedente.ContaBancaria.DigitoAgencia = "0";
+
+            cedente.Codigo = "3309894";
+
+            Boleto boleto = new Boleto(vencimento, 2701.40m, "101", "000000020061", cedente);
+
+            boleto.NumeroDocumento = "20061";
+            
+            boleto.Sacado = new Sacado("87425264188", "Sacado teste", new Endereco()
+            {
+                CEP = "78945612",
+                Cidade = "Teste",
+                UF = "PR",
+                End = "End teste",
+                Bairro = "Centro"
+            });
+
+            boleto.Instrucoes.Add(new Instrucao_Santander()
+            {
+                Codigo = 1,
+                Descricao = "teste"
+            });
+
+            var boletoBancario = new BoletoBancario();
+
+            boletoBancario.CodigoBanco = 33;
+
+            boletoBancario.Boleto = boleto;
+
+            return boletoBancario;
+        }
+
+        [TestMethod]
+        public void BancoSantander_GerarRemessaCNAB400()
+        {
+            var boletos = Enumerable.Range(0, 5).Select(o => {
+                var boleto = GerarBoletoRemessa();
+                return boleto;
+            });
+
+            Boletos itensRemessa = new Boletos();
+            itensRemessa.AddRange(boletos.Select(o => o.Boleto));
+
+            var banco = itensRemessa.First().Banco;
+            var cedente = itensRemessa.First().Cedente;
+            cedente.CodigoTransmissao = "01";
+
+            ArquivoRemessa arquivoRemessa = new ArquivoRemessa(TipoArquivo.CNAB400);
+            arquivoRemessa.LinhaDeArquivoGerada += (object sender, LinhaDeArquivoGeradaArgs e) =>
+            {
+                Debug.WriteLine(e.Linha);
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                arquivoRemessa.GerarArquivoRemessa("08111081111", banco, cedente, itensRemessa, stream, 1);
+                var conteudo = Encoding.ASCII.GetString(stream.ToArray());
+                Debug.WriteLine(conteudo);
+            }
+        }
         #endregion
     }
 }

--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
@@ -119,7 +119,7 @@ namespace BoletoNet
                         if (!string.IsNullOrEmpty(strline) && !string.IsNullOrWhiteSpace(strline))
                         { 
                             incluiLinha.WriteLine(strline);
-                            numeroRegistro++;
+                            //numeroRegistro++;
                         }
                     }
                 }


### PR DESCRIPTION
Quando havia instrucao no boleto, estava incrementando incorretamente o numero de registros.