### PR TITLE
Correção: Adicionada contagem de registros tipo 2 na remessa do CNAB 400 do Bradesco

### DIFF
--- a/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
+++ b/src/Boleto.Net/Arquivo/ArquivoRemessaCNAB400.cs
@@ -119,7 +119,6 @@ namespace BoletoNet
                         if (!string.IsNullOrEmpty(strline) && !string.IsNullOrWhiteSpace(strline))
                         { 
                             incluiLinha.WriteLine(strline);
-                            //numeroRegistro++;
                         }
                     }
                 }

--- a/src/Boleto.Net/Banco/Banco_Bradesco.cs
+++ b/src/Boleto.Net/Banco/Banco_Bradesco.cs
@@ -1266,6 +1266,9 @@ namespace BoletoNet
                 _detalhe += Utils.FitStringLength(numeroRegistro.ToString(), 6, 6, '0', 0, true, true, true);
 
                 _detalhe = Utils.SubstituiCaracteresEspeciais(_detalhe);
+
+                numeroRegistro++;
+
                 return _detalhe;
             }
             catch (Exception ex)


### PR DESCRIPTION
Após PR https://github.com/BoletoNet/boletonet/pull/953, o programa não contava o número de registros corretamente para registros tipo 2 do Bradesco.
Utilizado mesmo padrão feito pelo @carloscds no Santander.