### PR TITLE
Limita o tamanho da propaganda

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -628,7 +628,7 @@ namespace BoletoNet
 
             if (FormatoPropaganda)
             {
-                html.Append(string.Format("<img src='data:image/png;base64, {0}' />", ImagemPropaganda));
+                html.Append(string.Format("<img src='data:image/png;base64, {0}' height=\"600\"/>", ImagemPropaganda));
             }
 
             //Oculta o cabeçalho das instruções do boleto


### PR DESCRIPTION
Delimita a altura da propaganda para nao ocasionar a quebra de página se a figura for muito grande