### PR TITLE
Quebra a linha do pix se nao tiver espaço

### DIFF
--- a/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
+++ b/src/Boleto.Net/BoletoImpressao/BoletoBancario.cs
@@ -542,7 +542,7 @@ namespace BoletoNet
                     return html.ToString().Replace("@INSTRUCOES", _instrucoesHtml).Replace("@QRCODE", "").Replace("@COPIARCOLAR", "");
                 else
                 {
-                    string copiarColar = string.Format("Escolha a forma mais conveniente para realizar seu pagamento: <b><i>Código de Barras</i></b> ou <b><i>QR Code</i></b>. Basta acessar o aplicativo da sua instituição financeira e utilizar apenas uma das opções.<br><br><b>Pix Copia e Cola</b><br><font color='Blue'>{0}</font>", this.Boleto.QRCode);
+                    string copiarColar = string.Format("Escolha a forma mais conveniente para realizar seu pagamento: <b><i>Código de Barras</i></b> ou <b><i>QR Code</i></b>. Basta acessar o aplicativo da sua instituição financeira e utilizar apenas uma das opções.<br><br><b>Pix Copia e Cola</b><br><font color='Blue'>{0}</font>", FormataTextoPix(this.Boleto.QRCode));
                     string qrCode = QRCodeHelper.GerarQrCode(this.Boleto.QRCode);
                     string fnQRCode = string.Format("data:image/jpeg;base64,{0}", qrCode);
                     return html.ToString().Replace("@INSTRUCOES", _instrucoesHtml)
@@ -555,7 +555,18 @@ namespace BoletoNet
                 throw new Exception("Erro na execução da transação.", ex);
             }
         }
+	
+        private string FormataTextoPix(string stringToQrCode)
+        {
+            if (string.IsNullOrEmpty(stringToQrCode))
+                return string.Empty;
 
+            if (stringToQrCode.Contains(" ") && stringToQrCode.IndexOf(" ") < 70)
+                return stringToQrCode;
+
+            return stringToQrCode.Insert(70, "<br>");
+        }
+	
         private void MontaInstrucaoCaixa()
         {
             //Suelton - 12/03/2018
@@ -628,7 +639,7 @@ namespace BoletoNet
 
             if (FormatoPropaganda)
             {
-                html.Append(string.Format("<img src='data:image/png;base64, {0}' />", ImagemPropaganda));
+                html.Append(string.Format("<img src='data:image/png;base64, {0}' height=\"600\"/>", ImagemPropaganda));
             }
 
             //Oculta o cabeçalho das instruções do boleto


### PR DESCRIPTION
Quebra o texto do pix copia e cola, para evitar problema do layout

Texto sem espaços, que distorce o layout

![image](https://github.com/user-attachments/assets/8af844be-344d-4443-814d-2e21501c5655)

Layout após a correção

![image](https://github.com/user-attachments/assets/083b2a58-565f-467b-ad98-41b4b7e692fd)
