### PR TITLE
Correção digito verificador do código do Banco Daycoval

### DIFF
--- a/src/Boleto.Net/Banco/Banco_Daycoval.cs
+++ b/src/Boleto.Net/Banco/Banco_Daycoval.cs
@@ -32,7 +32,7 @@ namespace BoletoNet
 		internal Banco_Daycoval()
 		{
 			this.Codigo = 707;
-			this.Digito = "0";
+			this.Digito = "2";
 			this.Nome = "Daycoval";
 		}
 


### PR DESCRIPTION
Estava "0" e o correto, segundo documentação é "2". A impressão dos boletos, onde se informa o código do banco e seu digito verificador, ficará correta : "707-2"